### PR TITLE
Added comparisons to MD file

### DIFF
--- a/vulnz/kanishkanambiar.md
+++ b/vulnz/kanishkanambiar.md
@@ -1,0 +1,1274 @@
+NAME                          INSTALLED                     FIXED-IN     TYPE  VULNERABILITY        SEVERITY   
+apt                           2.2.4                                      deb   CVE-2011-3374        Negligible  
+bash                          5.1-2+deb11u1                 (won't fix)  deb   CVE-2022-3715        High        
+binutils                      2.35.2-2                                   deb   CVE-2023-25588       Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2023-25586       Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2023-25585       Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2023-25584       Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2023-1972        Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2023-1579        Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2022-48065       Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2022-48064       Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2022-48063       Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2022-47696       Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2022-47695       Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2022-47673       Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2022-47011       Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2022-47010       Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2022-47008       Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2022-47007       Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2022-45703       Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2022-44840       Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2022-4285        Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2022-38533       Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2022-35206       Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2022-35205       Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2021-46195       Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2021-46174       Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2021-45078       Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2021-3826        Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2021-3549        Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2021-3530        Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2021-32256       Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2021-20284       Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2021-20197       Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2020-35448       Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2020-19726       Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2019-1010204     Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2018-9996        Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2018-20712       Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2018-20673       Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2018-18483       Negligible  
+binutils                      2.35.2-2                                   deb   CVE-2017-13716       Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2023-25588       Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2023-25586       Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2023-25585       Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2023-25584       Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2023-1972        Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2023-1579        Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2022-48065       Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2022-48064       Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2022-48063       Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2022-47696       Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2022-47695       Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2022-47673       Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2022-47011       Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2022-47010       Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2022-47008       Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2022-47007       Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2022-45703       Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2022-44840       Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2022-4285        Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2022-38533       Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2022-35206       Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2022-35205       Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2021-46195       Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2021-46174       Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2021-45078       Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2021-3826        Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2021-3549        Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2021-3530        Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2021-32256       Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2021-20284       Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2021-20197       Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2020-35448       Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2020-19726       Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2019-1010204     Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2018-9996        Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2018-20712       Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2018-20673       Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2018-18483       Negligible  
+binutils-aarch64-linux-gnu    2.35.2-2                                   deb   CVE-2017-13716       Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2023-25588       Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2023-25586       Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2023-25585       Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2023-25584       Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2023-1972        Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2023-1579        Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2022-48065       Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2022-48064       Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2022-48063       Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2022-47696       Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2022-47695       Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2022-47673       Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2022-47011       Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2022-47010       Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2022-47008       Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2022-47007       Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2022-45703       Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2022-44840       Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2022-4285        Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2022-38533       Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2022-35206       Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2022-35205       Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2021-46195       Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2021-46174       Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2021-45078       Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2021-3826        Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2021-3549        Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2021-3530        Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2021-32256       Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2021-20284       Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2021-20197       Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2020-35448       Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2020-19726       Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2019-1010204     Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2018-9996        Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2018-20712       Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2018-20673       Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2018-18483       Negligible  
+binutils-common               2.35.2-2                                   deb   CVE-2017-13716       Negligible  
+bsdutils                      1:2.36.1-8+deb11u1                         deb   CVE-2022-0563        Negligible  
+comerr-dev                    2.1-1.46.2-2                  (won't fix)  deb   CVE-2022-1304        High        
+coreutils                     8.32-4                        (won't fix)  deb   CVE-2016-2781        Low         
+coreutils                     8.32-4                                     deb   CVE-2017-18018       Negligible  
+cpp-10                        10.2.1-6                      (won't fix)  deb   CVE-2023-4039        Medium      
+curl                          7.74.0-1.3+deb11u11           (won't fix)  deb   CVE-2023-23914       Critical    
+curl                          7.74.0-1.3+deb11u11           (won't fix)  deb   CVE-2022-43551       High        
+curl                          7.74.0-1.3+deb11u11           (won't fix)  deb   CVE-2022-42916       High        
+curl                          7.74.0-1.3+deb11u11           (won't fix)  deb   CVE-2023-46219       Medium      
+curl                          7.74.0-1.3+deb11u11           (won't fix)  deb   CVE-2023-23915       Medium      
+curl                          7.74.0-1.3+deb11u11                        deb   CVE-2023-28320       Negligible  
+curl                          7.74.0-1.3+deb11u11                        deb   CVE-2021-22923       Negligible  
+curl                          7.74.0-1.3+deb11u11                        deb   CVE-2021-22922       Negligible  
+dirmngr                       2.2.27-2+deb11u2                           deb   CVE-2022-3219        Negligible  
+e2fsprogs                     1.46.2-2                      (won't fix)  deb   CVE-2022-1304        High        
+g++-10                        10.2.1-6                      (won't fix)  deb   CVE-2023-4039        Medium      
+gcc-10                        10.2.1-6                      (won't fix)  deb   CVE-2023-4039        Medium      
+gcc-10-base                   10.2.1-6                      (won't fix)  deb   CVE-2023-4039        Medium      
+gcc-9-base                    9.3.0-22                      (won't fix)  deb   CVE-2023-4039        Medium      
+gir1.2-gdkpixbuf-2.0          2.42.2+dfsg-1+deb11u1         (won't fix)  deb   CVE-2022-48622       High        
+git                           1:2.30.2-1+deb11u2            (won't fix)  deb   CVE-2023-29007       High        
+git                           1:2.30.2-1+deb11u2            (won't fix)  deb   CVE-2023-25652       High        
+git                           1:2.30.2-1+deb11u2            (won't fix)  deb   CVE-2023-25815       Low         
+git                           1:2.30.2-1+deb11u2                         deb   CVE-2022-24975       Negligible  
+git                           1:2.30.2-1+deb11u2                         deb   CVE-2018-1000021     Negligible  
+git-man                       1:2.30.2-1+deb11u2            (won't fix)  deb   CVE-2023-29007       High        
+git-man                       1:2.30.2-1+deb11u2            (won't fix)  deb   CVE-2023-25652       High        
+git-man                       1:2.30.2-1+deb11u2            (won't fix)  deb   CVE-2023-25815       Low         
+git-man                       1:2.30.2-1+deb11u2                         deb   CVE-2022-24975       Negligible  
+git-man                       1:2.30.2-1+deb11u2                         deb   CVE-2018-1000021     Negligible  
+gnupg                         2.2.27-2+deb11u2                           deb   CVE-2022-3219        Negligible  
+gnupg-l10n                    2.2.27-2+deb11u2                           deb   CVE-2022-3219        Negligible  
+gnupg-utils                   2.2.27-2+deb11u2                           deb   CVE-2022-3219        Negligible  
+gpg                           2.2.27-2+deb11u2                           deb   CVE-2022-3219        Negligible  
+gpg-agent                     2.2.27-2+deb11u2                           deb   CVE-2022-3219        Negligible  
+gpg-wks-client                2.2.27-2+deb11u2                           deb   CVE-2022-3219        Negligible  
+gpg-wks-server                2.2.27-2+deb11u2                           deb   CVE-2022-3219        Negligible  
+gpgconf                       2.2.27-2+deb11u2                           deb   CVE-2022-3219        Negligible  
+gpgsm                         2.2.27-2+deb11u2                           deb   CVE-2022-3219        Negligible  
+gpgv                          2.2.27-2+deb11u2                           deb   CVE-2022-3219        Negligible  
+imagemagick                   8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2022-32547       High        
+imagemagick                   8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-40211       High        
+imagemagick                   8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-20313       High        
+imagemagick                   8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-20312       High        
+imagemagick                   8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2023-3195        Medium      
+imagemagick                   8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2023-2157        Medium      
+imagemagick                   8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2022-3213        Medium      
+imagemagick                   8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2023-34152       Negligible  
+imagemagick                   8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2021-20311       Negligible  
+imagemagick                   8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2018-15607       Negligible  
+imagemagick                   8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-7275        Negligible  
+imagemagick                   8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-11755       Negligible  
+imagemagick                   8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-11754       Negligible  
+imagemagick                   8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2016-8678        Negligible  
+imagemagick                   8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2008-3134        Negligible  
+imagemagick                   8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2005-0406        Negligible  
+imagemagick-6-common          8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2022-32547       High        
+imagemagick-6-common          8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-40211       High        
+imagemagick-6-common          8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-20313       High        
+imagemagick-6-common          8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-20312       High        
+imagemagick-6-common          8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2023-3195        Medium      
+imagemagick-6-common          8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2023-2157        Medium      
+imagemagick-6-common          8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2022-3213        Medium      
+imagemagick-6-common          8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2023-34152       Negligible  
+imagemagick-6-common          8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2021-20311       Negligible  
+imagemagick-6-common          8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2018-15607       Negligible  
+imagemagick-6-common          8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-7275        Negligible  
+imagemagick-6-common          8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-11755       Negligible  
+imagemagick-6-common          8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-11754       Negligible  
+imagemagick-6-common          8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2016-8678        Negligible  
+imagemagick-6-common          8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2008-3134        Negligible  
+imagemagick-6-common          8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2005-0406        Negligible  
+imagemagick-6.q16             8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2022-32547       High        
+imagemagick-6.q16             8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-40211       High        
+imagemagick-6.q16             8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-20313       High        
+imagemagick-6.q16             8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-20312       High        
+imagemagick-6.q16             8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2023-3195        Medium      
+imagemagick-6.q16             8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2023-2157        Medium      
+imagemagick-6.q16             8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2022-3213        Medium      
+imagemagick-6.q16             8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2023-34152       Negligible  
+imagemagick-6.q16             8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2021-20311       Negligible  
+imagemagick-6.q16             8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2018-15607       Negligible  
+imagemagick-6.q16             8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-7275        Negligible  
+imagemagick-6.q16             8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-11755       Negligible  
+imagemagick-6.q16             8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-11754       Negligible  
+imagemagick-6.q16             8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2016-8678        Negligible  
+imagemagick-6.q16             8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2008-3134        Negligible  
+imagemagick-6.q16             8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2005-0406        Negligible  
+jsonwebtoken                  8.5.1                         9.0.0        npm   GHSA-qwph-4952-7xr6  Medium      
+jsonwebtoken                  8.5.1                         9.0.0        npm   GHSA-hjrf-2m68-5959  Medium      
+jsonwebtoken                  8.5.1                         9.0.0        npm   GHSA-8cf7-32gw-wr33  Medium      
+krb5-multidev                 1.18.3-6+deb11u4                           deb   CVE-2018-5709        Negligible  
+krb5-multidev                 1.18.3-6+deb11u4              (won't fix)  deb   CVE-2024-26462       Unknown     
+krb5-multidev                 1.18.3-6+deb11u4              (won't fix)  deb   CVE-2024-26461       Unknown     
+krb5-multidev                 1.18.3-6+deb11u4              (won't fix)  deb   CVE-2024-26458       Unknown     
+libaom0                       1.0.0.errata1-3+deb11u1       (won't fix)  deb   CVE-2023-6879        Critical    
+libaom0                       1.0.0.errata1-3+deb11u1       (won't fix)  deb   CVE-2020-0478        High        
+libapt-pkg6.0                 2.2.4                                      deb   CVE-2011-3374        Negligible  
+libasan6                      10.2.1-6                      (won't fix)  deb   CVE-2023-4039        Medium      
+libatomic1                    10.2.1-6                      (won't fix)  deb   CVE-2023-4039        Medium      
+libbinutils                   2.35.2-2                                   deb   CVE-2023-25588       Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2023-25586       Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2023-25585       Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2023-25584       Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2023-1972        Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2023-1579        Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2022-48065       Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2022-48064       Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2022-48063       Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2022-47696       Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2022-47695       Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2022-47673       Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2022-47011       Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2022-47010       Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2022-47008       Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2022-47007       Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2022-45703       Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2022-44840       Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2022-4285        Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2022-38533       Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2022-35206       Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2022-35205       Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2021-46195       Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2021-46174       Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2021-45078       Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2021-3826        Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2021-3549        Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2021-3530        Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2021-32256       Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2021-20284       Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2021-20197       Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2020-35448       Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2020-19726       Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2019-1010204     Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2018-9996        Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2018-20712       Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2018-20673       Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2018-18483       Negligible  
+libbinutils                   2.35.2-2                                   deb   CVE-2017-13716       Negligible  
+libblkid-dev                  2.36.1-8+deb11u1                           deb   CVE-2022-0563        Negligible  
+libblkid1                     2.36.1-8+deb11u1                           deb   CVE-2022-0563        Negligible  
+libc-bin                      2.31-13+deb11u8               (won't fix)  deb   CVE-2023-4813        Medium      
+libc-bin                      2.31-13+deb11u8               (won't fix)  deb   CVE-2023-4806        Medium      
+libc-bin                      2.31-13+deb11u8                            deb   CVE-2019-9192        Negligible  
+libc-bin                      2.31-13+deb11u8                            deb   CVE-2019-1010025     Negligible  
+libc-bin                      2.31-13+deb11u8                            deb   CVE-2019-1010024     Negligible  
+libc-bin                      2.31-13+deb11u8                            deb   CVE-2019-1010023     Negligible  
+libc-bin                      2.31-13+deb11u8                            deb   CVE-2019-1010022     Negligible  
+libc-bin                      2.31-13+deb11u8                            deb   CVE-2018-20796       Negligible  
+libc-bin                      2.31-13+deb11u8                            deb   CVE-2010-4756        Negligible  
+libc-dev-bin                  2.31-13+deb11u8               (won't fix)  deb   CVE-2023-4813        Medium      
+libc-dev-bin                  2.31-13+deb11u8               (won't fix)  deb   CVE-2023-4806        Medium      
+libc-dev-bin                  2.31-13+deb11u8                            deb   CVE-2019-9192        Negligible  
+libc-dev-bin                  2.31-13+deb11u8                            deb   CVE-2019-1010025     Negligible  
+libc-dev-bin                  2.31-13+deb11u8                            deb   CVE-2019-1010024     Negligible  
+libc-dev-bin                  2.31-13+deb11u8                            deb   CVE-2019-1010023     Negligible  
+libc-dev-bin                  2.31-13+deb11u8                            deb   CVE-2019-1010022     Negligible  
+libc-dev-bin                  2.31-13+deb11u8                            deb   CVE-2018-20796       Negligible  
+libc-dev-bin                  2.31-13+deb11u8                            deb   CVE-2010-4756        Negligible  
+libc6                         2.31-13+deb11u8               (won't fix)  deb   CVE-2023-4813        Medium      
+libc6                         2.31-13+deb11u8               (won't fix)  deb   CVE-2023-4806        Medium      
+libc6                         2.31-13+deb11u8                            deb   CVE-2019-9192        Negligible  
+libc6                         2.31-13+deb11u8                            deb   CVE-2019-1010025     Negligible  
+libc6                         2.31-13+deb11u8                            deb   CVE-2019-1010024     Negligible  
+libc6                         2.31-13+deb11u8                            deb   CVE-2019-1010023     Negligible  
+libc6                         2.31-13+deb11u8                            deb   CVE-2019-1010022     Negligible  
+libc6                         2.31-13+deb11u8                            deb   CVE-2018-20796       Negligible  
+libc6                         2.31-13+deb11u8                            deb   CVE-2010-4756        Negligible  
+libc6-dev                     2.31-13+deb11u8               (won't fix)  deb   CVE-2023-4813        Medium      
+libc6-dev                     2.31-13+deb11u8               (won't fix)  deb   CVE-2023-4806        Medium      
+libc6-dev                     2.31-13+deb11u8                            deb   CVE-2019-9192        Negligible  
+libc6-dev                     2.31-13+deb11u8                            deb   CVE-2019-1010025     Negligible  
+libc6-dev                     2.31-13+deb11u8                            deb   CVE-2019-1010024     Negligible  
+libc6-dev                     2.31-13+deb11u8                            deb   CVE-2019-1010023     Negligible  
+libc6-dev                     2.31-13+deb11u8                            deb   CVE-2019-1010022     Negligible  
+libc6-dev                     2.31-13+deb11u8                            deb   CVE-2018-20796       Negligible  
+libc6-dev                     2.31-13+deb11u8                            deb   CVE-2010-4756        Negligible  
+libcairo-gobject2             1.16.0-5                      (won't fix)  deb   CVE-2019-6462        Low         
+libcairo-gobject2             1.16.0-5                      (won't fix)  deb   CVE-2019-6461        Low         
+libcairo-gobject2             1.16.0-5                      (won't fix)  deb   CVE-2018-18064       Low         
+libcairo-gobject2             1.16.0-5                      (won't fix)  deb   CVE-2017-7475        Low         
+libcairo-script-interpreter2  1.16.0-5                      (won't fix)  deb   CVE-2019-6462        Low         
+libcairo-script-interpreter2  1.16.0-5                      (won't fix)  deb   CVE-2019-6461        Low         
+libcairo-script-interpreter2  1.16.0-5                      (won't fix)  deb   CVE-2018-18064       Low         
+libcairo-script-interpreter2  1.16.0-5                      (won't fix)  deb   CVE-2017-7475        Low         
+libcairo2                     1.16.0-5                      (won't fix)  deb   CVE-2019-6462        Low         
+libcairo2                     1.16.0-5                      (won't fix)  deb   CVE-2019-6461        Low         
+libcairo2                     1.16.0-5                      (won't fix)  deb   CVE-2018-18064       Low         
+libcairo2                     1.16.0-5                      (won't fix)  deb   CVE-2017-7475        Low         
+libcairo2-dev                 1.16.0-5                      (won't fix)  deb   CVE-2019-6462        Low         
+libcairo2-dev                 1.16.0-5                      (won't fix)  deb   CVE-2019-6461        Low         
+libcairo2-dev                 1.16.0-5                      (won't fix)  deb   CVE-2018-18064       Low         
+libcairo2-dev                 1.16.0-5                      (won't fix)  deb   CVE-2017-7475        Low         
+libcc1-0                      10.2.1-6                      (won't fix)  deb   CVE-2023-4039        Medium      
+libcom-err2                   1.46.2-2                      (won't fix)  deb   CVE-2022-1304        High        
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2023-25588       Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2023-25586       Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2023-25585       Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2023-25584       Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2023-1972        Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2023-1579        Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2022-48065       Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2022-48064       Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2022-48063       Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2022-47696       Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2022-47695       Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2022-47673       Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2022-47011       Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2022-47010       Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2022-47008       Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2022-47007       Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2022-45703       Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2022-44840       Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2022-4285        Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2022-38533       Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2022-35206       Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2022-35205       Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2021-46195       Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2021-46174       Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2021-45078       Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2021-3826        Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2021-3549        Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2021-3530        Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2021-32256       Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2021-20284       Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2021-20197       Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2020-35448       Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2020-19726       Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2019-1010204     Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2018-9996        Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2018-20712       Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2018-20673       Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2018-18483       Negligible  
+libctf-nobfd0                 2.35.2-2                                   deb   CVE-2017-13716       Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2023-25588       Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2023-25586       Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2023-25585       Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2023-25584       Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2023-1972        Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2023-1579        Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2022-48065       Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2022-48064       Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2022-48063       Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2022-47696       Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2022-47695       Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2022-47673       Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2022-47011       Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2022-47010       Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2022-47008       Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2022-47007       Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2022-45703       Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2022-44840       Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2022-4285        Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2022-38533       Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2022-35206       Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2022-35205       Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2021-46195       Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2021-46174       Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2021-45078       Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2021-3826        Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2021-3549        Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2021-3530        Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2021-32256       Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2021-20284       Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2021-20197       Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2020-35448       Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2020-19726       Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2019-1010204     Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2018-9996        Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2018-20712       Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2018-20673       Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2018-18483       Negligible  
+libctf0                       2.35.2-2                                   deb   CVE-2017-13716       Negligible  
+libcurl3-gnutls               7.74.0-1.3+deb11u11           (won't fix)  deb   CVE-2023-23914       Critical    
+libcurl3-gnutls               7.74.0-1.3+deb11u11           (won't fix)  deb   CVE-2022-43551       High        
+libcurl3-gnutls               7.74.0-1.3+deb11u11           (won't fix)  deb   CVE-2022-42916       High        
+libcurl3-gnutls               7.74.0-1.3+deb11u11           (won't fix)  deb   CVE-2023-46219       Medium      
+libcurl3-gnutls               7.74.0-1.3+deb11u11           (won't fix)  deb   CVE-2023-23915       Medium      
+libcurl3-gnutls               7.74.0-1.3+deb11u11                        deb   CVE-2023-28320       Negligible  
+libcurl3-gnutls               7.74.0-1.3+deb11u11                        deb   CVE-2021-22923       Negligible  
+libcurl3-gnutls               7.74.0-1.3+deb11u11                        deb   CVE-2021-22922       Negligible  
+libcurl4                      7.74.0-1.3+deb11u11           (won't fix)  deb   CVE-2023-23914       Critical    
+libcurl4                      7.74.0-1.3+deb11u11           (won't fix)  deb   CVE-2022-43551       High        
+libcurl4                      7.74.0-1.3+deb11u11           (won't fix)  deb   CVE-2022-42916       High        
+libcurl4                      7.74.0-1.3+deb11u11           (won't fix)  deb   CVE-2023-46219       Medium      
+libcurl4                      7.74.0-1.3+deb11u11           (won't fix)  deb   CVE-2023-23915       Medium      
+libcurl4                      7.74.0-1.3+deb11u11                        deb   CVE-2023-28320       Negligible  
+libcurl4                      7.74.0-1.3+deb11u11                        deb   CVE-2021-22923       Negligible  
+libcurl4                      7.74.0-1.3+deb11u11                        deb   CVE-2021-22922       Negligible  
+libcurl4-openssl-dev          7.74.0-1.3+deb11u11           (won't fix)  deb   CVE-2023-23914       Critical    
+libcurl4-openssl-dev          7.74.0-1.3+deb11u11           (won't fix)  deb   CVE-2022-43551       High        
+libcurl4-openssl-dev          7.74.0-1.3+deb11u11           (won't fix)  deb   CVE-2022-42916       High        
+libcurl4-openssl-dev          7.74.0-1.3+deb11u11           (won't fix)  deb   CVE-2023-46219       Medium      
+libcurl4-openssl-dev          7.74.0-1.3+deb11u11           (won't fix)  deb   CVE-2023-23915       Medium      
+libcurl4-openssl-dev          7.74.0-1.3+deb11u11                        deb   CVE-2023-28320       Negligible  
+libcurl4-openssl-dev          7.74.0-1.3+deb11u11                        deb   CVE-2021-22923       Negligible  
+libcurl4-openssl-dev          7.74.0-1.3+deb11u11                        deb   CVE-2021-22922       Negligible  
+libdav1d4                     0.7.1-3                                    deb   CVE-2024-1580        Medium      
+libdav1d4                     0.7.1-3                       (won't fix)  deb   CVE-2023-32570       Medium      
+libdb5.3                      5.3.28+dfsg1-0.8              (won't fix)  deb   CVE-2019-8457        Critical    
+libdb5.3-dev                  5.3.28+dfsg1-0.8              (won't fix)  deb   CVE-2019-8457        Critical    
+libdjvulibre-dev              3.5.28-2                      (won't fix)  deb   CVE-2021-46312       Medium      
+libdjvulibre-dev              3.5.28-2                      (won't fix)  deb   CVE-2021-46310       Medium      
+libdjvulibre-text             3.5.28-2                      (won't fix)  deb   CVE-2021-46312       Medium      
+libdjvulibre-text             3.5.28-2                      (won't fix)  deb   CVE-2021-46310       Medium      
+libdjvulibre21                3.5.28-2                      (won't fix)  deb   CVE-2021-46312       Medium      
+libdjvulibre21                3.5.28-2                      (won't fix)  deb   CVE-2021-46310       Medium      
+libelf1                       0.183-1                                    deb   CVE-2024-25260       Negligible  
+libelf1                       0.183-1                                    deb   CVE-2021-33294       Negligible  
+libexpat1                     2.2.10-2+deb11u5                           deb   CVE-2023-52425       High        
+libexpat1                     2.2.10-2+deb11u5                           deb   CVE-2023-52426       Medium      
+libexpat1                     2.2.10-2+deb11u5                           deb   CVE-2013-0340        Negligible  
+libexpat1                     2.2.10-2+deb11u5                           deb   CVE-2024-28757       Unknown     
+libexpat1-dev                 2.2.10-2+deb11u5                           deb   CVE-2023-52425       High        
+libexpat1-dev                 2.2.10-2+deb11u5                           deb   CVE-2023-52426       Medium      
+libexpat1-dev                 2.2.10-2+deb11u5                           deb   CVE-2013-0340        Negligible  
+libexpat1-dev                 2.2.10-2+deb11u5                           deb   CVE-2024-28757       Unknown     
+libext2fs2                    1.46.2-2                      (won't fix)  deb   CVE-2022-1304        High        
+libfreetype-dev               2.10.4+dfsg-1+deb11u1                      deb   CVE-2022-31782       Negligible  
+libfreetype6                  2.10.4+dfsg-1+deb11u1                      deb   CVE-2022-31782       Negligible  
+libfreetype6-dev              2.10.4+dfsg-1+deb11u1                      deb   CVE-2022-31782       Negligible  
+libgcc-10-dev                 10.2.1-6                      (won't fix)  deb   CVE-2023-4039        Medium      
+libgcc-s1                     10.2.1-6                      (won't fix)  deb   CVE-2023-4039        Medium      
+libgcrypt20                   1.8.7-6                       (won't fix)  deb   CVE-2021-33560       High        
+libgcrypt20                   1.8.7-6                       (won't fix)  deb   CVE-2024-2236        Medium      
+libgcrypt20                   1.8.7-6                                    deb   CVE-2018-6829        Negligible  
+libgdk-pixbuf-2.0-0           2.42.2+dfsg-1+deb11u1         (won't fix)  deb   CVE-2022-48622       High        
+libgdk-pixbuf-2.0-dev         2.42.2+dfsg-1+deb11u1         (won't fix)  deb   CVE-2022-48622       High        
+libgdk-pixbuf2.0-bin          2.42.2+dfsg-1+deb11u1         (won't fix)  deb   CVE-2022-48622       High        
+libgdk-pixbuf2.0-common       2.42.2+dfsg-1+deb11u1         (won't fix)  deb   CVE-2022-48622       High        
+libglib2.0-0                  2.66.8-1+deb11u1                           deb   CVE-2012-0039        Negligible  
+libglib2.0-bin                2.66.8-1+deb11u1                           deb   CVE-2012-0039        Negligible  
+libglib2.0-data               2.66.8-1+deb11u1                           deb   CVE-2012-0039        Negligible  
+libglib2.0-dev                2.66.8-1+deb11u1                           deb   CVE-2012-0039        Negligible  
+libglib2.0-dev-bin            2.66.8-1+deb11u1                           deb   CVE-2012-0039        Negligible  
+libgnutls30                   3.7.1-5+deb11u4               (won't fix)  deb   CVE-2024-0567        High        
+libgnutls30                   3.7.1-5+deb11u4               (won't fix)  deb   CVE-2024-0553        High        
+libgnutls30                   3.7.1-5+deb11u4                            deb   CVE-2011-3389        Negligible  
+libgomp1                      10.2.1-6                      (won't fix)  deb   CVE-2023-4039        Medium      
+libgssapi-krb5-2              1.18.3-6+deb11u4                           deb   CVE-2018-5709        Negligible  
+libgssapi-krb5-2              1.18.3-6+deb11u4              (won't fix)  deb   CVE-2024-26462       Unknown     
+libgssapi-krb5-2              1.18.3-6+deb11u4              (won't fix)  deb   CVE-2024-26461       Unknown     
+libgssapi-krb5-2              1.18.3-6+deb11u4              (won't fix)  deb   CVE-2024-26458       Unknown     
+libgssrpc4                    1.18.3-6+deb11u4                           deb   CVE-2018-5709        Negligible  
+libgssrpc4                    1.18.3-6+deb11u4              (won't fix)  deb   CVE-2024-26462       Unknown     
+libgssrpc4                    1.18.3-6+deb11u4              (won't fix)  deb   CVE-2024-26461       Unknown     
+libgssrpc4                    1.18.3-6+deb11u4              (won't fix)  deb   CVE-2024-26458       Unknown     
+libharfbuzz0b                 2.7.4-1                       (won't fix)  deb   CVE-2023-25193       High        
+libharfbuzz0b                 2.7.4-1                       (won't fix)  deb   CVE-2022-33068       Medium      
+libheif1                      1.11.0-1                      (won't fix)  deb   CVE-2023-49464       High        
+libheif1                      1.11.0-1                      (won't fix)  deb   CVE-2023-49463       High        
+libheif1                      1.11.0-1                      (won't fix)  deb   CVE-2023-49462       High        
+libheif1                      1.11.0-1                      (won't fix)  deb   CVE-2023-49460       High        
+libheif1                      1.11.0-1                      (won't fix)  deb   CVE-2023-0996        High        
+libheif1                      1.11.0-1                      (won't fix)  deb   CVE-2023-29659       Medium      
+libheif1                      1.11.0-1                                   deb   CVE-2024-25269       Negligible  
+libitm1                       10.2.1-6                      (won't fix)  deb   CVE-2023-4039        Medium      
+libjbig-dev                   2.1-3.1+b2                                 deb   CVE-2017-9937        Negligible  
+libjbig0                      2.1-3.1+b2                                 deb   CVE-2017-9937        Negligible  
+libjpeg-dev                   1:2.0.6-4                     (won't fix)  deb   CVE-2021-46822       Medium      
+libjpeg62-turbo               1:2.0.6-4                     (won't fix)  deb   CVE-2021-46822       Medium      
+libjpeg62-turbo-dev           1:2.0.6-4                     (won't fix)  deb   CVE-2021-46822       Medium      
+libk5crypto3                  1.18.3-6+deb11u4                           deb   CVE-2018-5709        Negligible  
+libk5crypto3                  1.18.3-6+deb11u4              (won't fix)  deb   CVE-2024-26462       Unknown     
+libk5crypto3                  1.18.3-6+deb11u4              (won't fix)  deb   CVE-2024-26461       Unknown     
+libk5crypto3                  1.18.3-6+deb11u4              (won't fix)  deb   CVE-2024-26458       Unknown     
+libkadm5clnt-mit12            1.18.3-6+deb11u4                           deb   CVE-2018-5709        Negligible  
+libkadm5clnt-mit12            1.18.3-6+deb11u4              (won't fix)  deb   CVE-2024-26462       Unknown     
+libkadm5clnt-mit12            1.18.3-6+deb11u4              (won't fix)  deb   CVE-2024-26461       Unknown     
+libkadm5clnt-mit12            1.18.3-6+deb11u4              (won't fix)  deb   CVE-2024-26458       Unknown     
+libkadm5srv-mit12             1.18.3-6+deb11u4                           deb   CVE-2018-5709        Negligible  
+libkadm5srv-mit12             1.18.3-6+deb11u4              (won't fix)  deb   CVE-2024-26462       Unknown     
+libkadm5srv-mit12             1.18.3-6+deb11u4              (won't fix)  deb   CVE-2024-26461       Unknown     
+libkadm5srv-mit12             1.18.3-6+deb11u4              (won't fix)  deb   CVE-2024-26458       Unknown     
+libkdb5-10                    1.18.3-6+deb11u4                           deb   CVE-2018-5709        Negligible  
+libkdb5-10                    1.18.3-6+deb11u4              (won't fix)  deb   CVE-2024-26462       Unknown     
+libkdb5-10                    1.18.3-6+deb11u4              (won't fix)  deb   CVE-2024-26461       Unknown     
+libkdb5-10                    1.18.3-6+deb11u4              (won't fix)  deb   CVE-2024-26458       Unknown     
+libkrb5-3                     1.18.3-6+deb11u4                           deb   CVE-2018-5709        Negligible  
+libkrb5-3                     1.18.3-6+deb11u4              (won't fix)  deb   CVE-2024-26462       Unknown     
+libkrb5-3                     1.18.3-6+deb11u4              (won't fix)  deb   CVE-2024-26461       Unknown     
+libkrb5-3                     1.18.3-6+deb11u4              (won't fix)  deb   CVE-2024-26458       Unknown     
+libkrb5-dev                   1.18.3-6+deb11u4                           deb   CVE-2018-5709        Negligible  
+libkrb5-dev                   1.18.3-6+deb11u4              (won't fix)  deb   CVE-2024-26462       Unknown     
+libkrb5-dev                   1.18.3-6+deb11u4              (won't fix)  deb   CVE-2024-26461       Unknown     
+libkrb5-dev                   1.18.3-6+deb11u4              (won't fix)  deb   CVE-2024-26458       Unknown     
+libkrb5support0               1.18.3-6+deb11u4                           deb   CVE-2018-5709        Negligible  
+libkrb5support0               1.18.3-6+deb11u4              (won't fix)  deb   CVE-2024-26462       Unknown     
+libkrb5support0               1.18.3-6+deb11u4              (won't fix)  deb   CVE-2024-26461       Unknown     
+libkrb5support0               1.18.3-6+deb11u4              (won't fix)  deb   CVE-2024-26458       Unknown     
+libldap-2.4-2                 2.4.57+dfsg-3+deb11u1         (won't fix)  deb   CVE-2023-2953        High        
+libldap-2.4-2                 2.4.57+dfsg-3+deb11u1                      deb   CVE-2020-15719       Negligible  
+libldap-2.4-2                 2.4.57+dfsg-3+deb11u1                      deb   CVE-2017-17740       Negligible  
+libldap-2.4-2                 2.4.57+dfsg-3+deb11u1                      deb   CVE-2017-14159       Negligible  
+libldap-2.4-2                 2.4.57+dfsg-3+deb11u1                      deb   CVE-2015-3276        Negligible  
+liblsan0                      10.2.1-6                      (won't fix)  deb   CVE-2023-4039        Medium      
+libmagickcore-6-arch-config   8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2022-32547       High        
+libmagickcore-6-arch-config   8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-40211       High        
+libmagickcore-6-arch-config   8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-20313       High        
+libmagickcore-6-arch-config   8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-20312       High        
+libmagickcore-6-arch-config   8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2023-3195        Medium      
+libmagickcore-6-arch-config   8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2023-2157        Medium      
+libmagickcore-6-arch-config   8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2022-3213        Medium      
+libmagickcore-6-arch-config   8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2023-34152       Negligible  
+libmagickcore-6-arch-config   8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2021-20311       Negligible  
+libmagickcore-6-arch-config   8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2018-15607       Negligible  
+libmagickcore-6-arch-config   8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-7275        Negligible  
+libmagickcore-6-arch-config   8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-11755       Negligible  
+libmagickcore-6-arch-config   8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-11754       Negligible  
+libmagickcore-6-arch-config   8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2016-8678        Negligible  
+libmagickcore-6-arch-config   8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2008-3134        Negligible  
+libmagickcore-6-arch-config   8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2005-0406        Negligible  
+libmagickcore-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2022-32547       High        
+libmagickcore-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-40211       High        
+libmagickcore-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-20313       High        
+libmagickcore-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-20312       High        
+libmagickcore-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2023-3195        Medium      
+libmagickcore-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2023-2157        Medium      
+libmagickcore-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2022-3213        Medium      
+libmagickcore-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2023-34152       Negligible  
+libmagickcore-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2021-20311       Negligible  
+libmagickcore-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2018-15607       Negligible  
+libmagickcore-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-7275        Negligible  
+libmagickcore-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-11755       Negligible  
+libmagickcore-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-11754       Negligible  
+libmagickcore-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2016-8678        Negligible  
+libmagickcore-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2008-3134        Negligible  
+libmagickcore-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2005-0406        Negligible  
+libmagickcore-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2022-32547       High        
+libmagickcore-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-40211       High        
+libmagickcore-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-20313       High        
+libmagickcore-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-20312       High        
+libmagickcore-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2023-3195        Medium      
+libmagickcore-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2023-2157        Medium      
+libmagickcore-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2022-3213        Medium      
+libmagickcore-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2023-34152       Negligible  
+libmagickcore-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2021-20311       Negligible  
+libmagickcore-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2018-15607       Negligible  
+libmagickcore-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-7275        Negligible  
+libmagickcore-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-11755       Negligible  
+libmagickcore-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-11754       Negligible  
+libmagickcore-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2016-8678        Negligible  
+libmagickcore-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2008-3134        Negligible  
+libmagickcore-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2005-0406        Negligible  
+libmagickcore-6.q16-6-extra   8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2022-32547       High        
+libmagickcore-6.q16-6-extra   8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-40211       High        
+libmagickcore-6.q16-6-extra   8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-20313       High        
+libmagickcore-6.q16-6-extra   8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-20312       High        
+libmagickcore-6.q16-6-extra   8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2023-3195        Medium      
+libmagickcore-6.q16-6-extra   8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2023-2157        Medium      
+libmagickcore-6.q16-6-extra   8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2022-3213        Medium      
+libmagickcore-6.q16-6-extra   8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2023-34152       Negligible  
+libmagickcore-6.q16-6-extra   8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2021-20311       Negligible  
+libmagickcore-6.q16-6-extra   8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2018-15607       Negligible  
+libmagickcore-6.q16-6-extra   8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-7275        Negligible  
+libmagickcore-6.q16-6-extra   8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-11755       Negligible  
+libmagickcore-6.q16-6-extra   8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-11754       Negligible  
+libmagickcore-6.q16-6-extra   8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2016-8678        Negligible  
+libmagickcore-6.q16-6-extra   8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2008-3134        Negligible  
+libmagickcore-6.q16-6-extra   8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2005-0406        Negligible  
+libmagickcore-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2022-32547       High        
+libmagickcore-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-40211       High        
+libmagickcore-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-20313       High        
+libmagickcore-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-20312       High        
+libmagickcore-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2023-3195        Medium      
+libmagickcore-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2023-2157        Medium      
+libmagickcore-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2022-3213        Medium      
+libmagickcore-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2023-34152       Negligible  
+libmagickcore-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2021-20311       Negligible  
+libmagickcore-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2018-15607       Negligible  
+libmagickcore-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-7275        Negligible  
+libmagickcore-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-11755       Negligible  
+libmagickcore-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-11754       Negligible  
+libmagickcore-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2016-8678        Negligible  
+libmagickcore-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2008-3134        Negligible  
+libmagickcore-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2005-0406        Negligible  
+libmagickcore-dev             8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2022-32547       High        
+libmagickcore-dev             8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-40211       High        
+libmagickcore-dev             8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-20313       High        
+libmagickcore-dev             8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-20312       High        
+libmagickcore-dev             8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2023-3195        Medium      
+libmagickcore-dev             8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2023-2157        Medium      
+libmagickcore-dev             8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2022-3213        Medium      
+libmagickcore-dev             8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2023-34152       Negligible  
+libmagickcore-dev             8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2021-20311       Negligible  
+libmagickcore-dev             8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2018-15607       Negligible  
+libmagickcore-dev             8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-7275        Negligible  
+libmagickcore-dev             8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-11755       Negligible  
+libmagickcore-dev             8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-11754       Negligible  
+libmagickcore-dev             8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2016-8678        Negligible  
+libmagickcore-dev             8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2008-3134        Negligible  
+libmagickcore-dev             8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2005-0406        Negligible  
+libmagickwand-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2022-32547       High        
+libmagickwand-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-40211       High        
+libmagickwand-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-20313       High        
+libmagickwand-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-20312       High        
+libmagickwand-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2023-3195        Medium      
+libmagickwand-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2023-2157        Medium      
+libmagickwand-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2022-3213        Medium      
+libmagickwand-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2023-34152       Negligible  
+libmagickwand-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2021-20311       Negligible  
+libmagickwand-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2018-15607       Negligible  
+libmagickwand-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-7275        Negligible  
+libmagickwand-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-11755       Negligible  
+libmagickwand-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-11754       Negligible  
+libmagickwand-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2016-8678        Negligible  
+libmagickwand-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2008-3134        Negligible  
+libmagickwand-6-headers       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2005-0406        Negligible  
+libmagickwand-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2022-32547       High        
+libmagickwand-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-40211       High        
+libmagickwand-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-20313       High        
+libmagickwand-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-20312       High        
+libmagickwand-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2023-3195        Medium      
+libmagickwand-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2023-2157        Medium      
+libmagickwand-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2022-3213        Medium      
+libmagickwand-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2023-34152       Negligible  
+libmagickwand-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2021-20311       Negligible  
+libmagickwand-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2018-15607       Negligible  
+libmagickwand-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-7275        Negligible  
+libmagickwand-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-11755       Negligible  
+libmagickwand-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-11754       Negligible  
+libmagickwand-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2016-8678        Negligible  
+libmagickwand-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2008-3134        Negligible  
+libmagickwand-6.q16-6         8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2005-0406        Negligible  
+libmagickwand-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2022-32547       High        
+libmagickwand-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-40211       High        
+libmagickwand-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-20313       High        
+libmagickwand-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-20312       High        
+libmagickwand-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2023-3195        Medium      
+libmagickwand-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2023-2157        Medium      
+libmagickwand-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2022-3213        Medium      
+libmagickwand-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2023-34152       Negligible  
+libmagickwand-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2021-20311       Negligible  
+libmagickwand-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2018-15607       Negligible  
+libmagickwand-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-7275        Negligible  
+libmagickwand-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-11755       Negligible  
+libmagickwand-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-11754       Negligible  
+libmagickwand-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2016-8678        Negligible  
+libmagickwand-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2008-3134        Negligible  
+libmagickwand-6.q16-dev       8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2005-0406        Negligible  
+libmagickwand-dev             8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2022-32547       High        
+libmagickwand-dev             8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-40211       High        
+libmagickwand-dev             8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-20313       High        
+libmagickwand-dev             8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2021-20312       High        
+libmagickwand-dev             8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2023-3195        Medium      
+libmagickwand-dev             8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2023-2157        Medium      
+libmagickwand-dev             8:6.9.11.60+dfsg-1.3+deb11u3  (won't fix)  deb   CVE-2022-3213        Medium      
+libmagickwand-dev             8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2023-34152       Negligible  
+libmagickwand-dev             8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2021-20311       Negligible  
+libmagickwand-dev             8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2018-15607       Negligible  
+libmagickwand-dev             8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-7275        Negligible  
+libmagickwand-dev             8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-11755       Negligible  
+libmagickwand-dev             8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2017-11754       Negligible  
+libmagickwand-dev             8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2016-8678        Negligible  
+libmagickwand-dev             8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2008-3134        Negligible  
+libmagickwand-dev             8:6.9.11.60+dfsg-1.3+deb11u3               deb   CVE-2005-0406        Negligible  
+libmount-dev                  2.36.1-8+deb11u1                           deb   CVE-2022-0563        Negligible  
+libmount1                     2.36.1-8+deb11u1                           deb   CVE-2022-0563        Negligible  
+libncurses-dev                6.2+20201114-2+deb11u2        (won't fix)  deb   CVE-2023-50495       Medium      
+libncurses-dev                6.2+20201114-2+deb11u2        (won't fix)  deb   CVE-2023-45918       Unknown     
+libncurses5-dev               6.2+20201114-2+deb11u2        (won't fix)  deb   CVE-2023-50495       Medium      
+libncurses5-dev               6.2+20201114-2+deb11u2        (won't fix)  deb   CVE-2023-45918       Unknown     
+libncurses6                   6.2+20201114-2+deb11u2        (won't fix)  deb   CVE-2023-50495       Medium      
+libncurses6                   6.2+20201114-2+deb11u2        (won't fix)  deb   CVE-2023-45918       Unknown     
+libncursesw5-dev              6.2+20201114-2+deb11u2        (won't fix)  deb   CVE-2023-50495       Medium      
+libncursesw5-dev              6.2+20201114-2+deb11u2        (won't fix)  deb   CVE-2023-45918       Unknown     
+libncursesw6                  6.2+20201114-2+deb11u2        (won't fix)  deb   CVE-2023-50495       Medium      
+libncursesw6                  6.2+20201114-2+deb11u2        (won't fix)  deb   CVE-2023-45918       Unknown     
+libopenexr-dev                2.5.4-2+deb11u1                            deb   CVE-2021-26945       Negligible  
+libopenexr-dev                2.5.4-2+deb11u1                            deb   CVE-2017-14988       Negligible  
+libopenexr25                  2.5.4-2+deb11u1                            deb   CVE-2021-26945       Negligible  
+libopenexr25                  2.5.4-2+deb11u1                            deb   CVE-2017-14988       Negligible  
+libopenjp2-7                  2.4.0-3                       (won't fix)  deb   CVE-2021-3575        High        
+libopenjp2-7                  2.4.0-3                       (won't fix)  deb   CVE-2022-1122        Medium      
+libopenjp2-7                  2.4.0-3                       (won't fix)  deb   CVE-2021-29338       Medium      
+libopenjp2-7                  2.4.0-3                       (won't fix)  deb   CVE-2019-6988        Low         
+libopenjp2-7                  2.4.0-3                                    deb   CVE-2018-20846       Negligible  
+libopenjp2-7                  2.4.0-3                                    deb   CVE-2018-16376       Negligible  
+libopenjp2-7                  2.4.0-3                                    deb   CVE-2018-16375       Negligible  
+libopenjp2-7                  2.4.0-3                                    deb   CVE-2017-17479       Negligible  
+libopenjp2-7                  2.4.0-3                                    deb   CVE-2016-9581        Negligible  
+libopenjp2-7                  2.4.0-3                                    deb   CVE-2016-9580        Negligible  
+libopenjp2-7                  2.4.0-3                                    deb   CVE-2016-9117        Negligible  
+libopenjp2-7                  2.4.0-3                                    deb   CVE-2016-9116        Negligible  
+libopenjp2-7                  2.4.0-3                                    deb   CVE-2016-9115        Negligible  
+libopenjp2-7                  2.4.0-3                                    deb   CVE-2016-9114        Negligible  
+libopenjp2-7                  2.4.0-3                                    deb   CVE-2016-9113        Negligible  
+libopenjp2-7                  2.4.0-3                                    deb   CVE-2016-10506       Negligible  
+libopenjp2-7                  2.4.0-3                                    deb   CVE-2016-10505       Negligible  
+libopenjp2-7-dev              2.4.0-3                       (won't fix)  deb   CVE-2021-3575        High        
+libopenjp2-7-dev              2.4.0-3                       (won't fix)  deb   CVE-2022-1122        Medium      
+libopenjp2-7-dev              2.4.0-3                       (won't fix)  deb   CVE-2021-29338       Medium      
+libopenjp2-7-dev              2.4.0-3                       (won't fix)  deb   CVE-2019-6988        Low         
+libopenjp2-7-dev              2.4.0-3                                    deb   CVE-2018-20846       Negligible  
+libopenjp2-7-dev              2.4.0-3                                    deb   CVE-2018-16376       Negligible  
+libopenjp2-7-dev              2.4.0-3                                    deb   CVE-2018-16375       Negligible  
+libopenjp2-7-dev              2.4.0-3                                    deb   CVE-2017-17479       Negligible  
+libopenjp2-7-dev              2.4.0-3                                    deb   CVE-2016-9581        Negligible  
+libopenjp2-7-dev              2.4.0-3                                    deb   CVE-2016-9580        Negligible  
+libopenjp2-7-dev              2.4.0-3                                    deb   CVE-2016-9117        Negligible  
+libopenjp2-7-dev              2.4.0-3                                    deb   CVE-2016-9116        Negligible  
+libopenjp2-7-dev              2.4.0-3                                    deb   CVE-2016-9115        Negligible  
+libopenjp2-7-dev              2.4.0-3                                    deb   CVE-2016-9114        Negligible  
+libopenjp2-7-dev              2.4.0-3                                    deb   CVE-2016-9113        Negligible  
+libopenjp2-7-dev              2.4.0-3                                    deb   CVE-2016-10506       Negligible  
+libopenjp2-7-dev              2.4.0-3                                    deb   CVE-2016-10505       Negligible  
+libpam-modules                1.4.0-9+deb11u1               (won't fix)  deb   CVE-2024-22365       Medium      
+libpam-modules-bin            1.4.0-9+deb11u1               (won't fix)  deb   CVE-2024-22365       Medium      
+libpam-runtime                1.4.0-9+deb11u1               (won't fix)  deb   CVE-2024-22365       Medium      
+libpam0g                      1.4.0-9+deb11u1               (won't fix)  deb   CVE-2024-22365       Medium      
+libpcre16-3                   2:8.39-13                                  deb   CVE-2019-20838       Negligible  
+libpcre16-3                   2:8.39-13                                  deb   CVE-2017-7246        Negligible  
+libpcre16-3                   2:8.39-13                                  deb   CVE-2017-7245        Negligible  
+libpcre16-3                   2:8.39-13                                  deb   CVE-2017-16231       Negligible  
+libpcre16-3                   2:8.39-13                                  deb   CVE-2017-11164       Negligible  
+libpcre2-16-0                 10.36-2+deb11u1                            deb   CVE-2022-41409       Negligible  
+libpcre2-32-0                 10.36-2+deb11u1                            deb   CVE-2022-41409       Negligible  
+libpcre2-8-0                  10.36-2+deb11u1                            deb   CVE-2022-41409       Negligible  
+libpcre2-dev                  10.36-2+deb11u1                            deb   CVE-2022-41409       Negligible  
+libpcre2-posix2               10.36-2+deb11u1                            deb   CVE-2022-41409       Negligible  
+libpcre3                      2:8.39-13                                  deb   CVE-2019-20838       Negligible  
+libpcre3                      2:8.39-13                                  deb   CVE-2017-7246        Negligible  
+libpcre3                      2:8.39-13                                  deb   CVE-2017-7245        Negligible  
+libpcre3                      2:8.39-13                                  deb   CVE-2017-16231       Negligible  
+libpcre3                      2:8.39-13                                  deb   CVE-2017-11164       Negligible  
+libpcre3-dev                  2:8.39-13                                  deb   CVE-2019-20838       Negligible  
+libpcre3-dev                  2:8.39-13                                  deb   CVE-2017-7246        Negligible  
+libpcre3-dev                  2:8.39-13                                  deb   CVE-2017-7245        Negligible  
+libpcre3-dev                  2:8.39-13                                  deb   CVE-2017-16231       Negligible  
+libpcre3-dev                  2:8.39-13                                  deb   CVE-2017-11164       Negligible  
+libpcre32-3                   2:8.39-13                                  deb   CVE-2019-20838       Negligible  
+libpcre32-3                   2:8.39-13                                  deb   CVE-2017-7246        Negligible  
+libpcre32-3                   2:8.39-13                                  deb   CVE-2017-7245        Negligible  
+libpcre32-3                   2:8.39-13                                  deb   CVE-2017-16231       Negligible  
+libpcre32-3                   2:8.39-13                                  deb   CVE-2017-11164       Negligible  
+libpcrecpp0v5                 2:8.39-13                                  deb   CVE-2019-20838       Negligible  
+libpcrecpp0v5                 2:8.39-13                                  deb   CVE-2017-7246        Negligible  
+libpcrecpp0v5                 2:8.39-13                                  deb   CVE-2017-7245        Negligible  
+libpcrecpp0v5                 2:8.39-13                                  deb   CVE-2017-16231       Negligible  
+libpcrecpp0v5                 2:8.39-13                                  deb   CVE-2017-11164       Negligible  
+libperl5.32                   5.32.1-4+deb11u3              (won't fix)  deb   CVE-2023-31484       High        
+libperl5.32                   5.32.1-4+deb11u3              (won't fix)  deb   CVE-2020-16156       High        
+libperl5.32                   5.32.1-4+deb11u3                           deb   CVE-2023-31486       Negligible  
+libperl5.32                   5.32.1-4+deb11u3                           deb   CVE-2011-4116        Negligible  
+libpixman-1-0                 0.40.0-1.1~deb11u1                         deb   CVE-2023-37769       Negligible  
+libpixman-1-dev               0.40.0-1.1~deb11u1                         deb   CVE-2023-37769       Negligible  
+libpng-dev                    1.6.37-3                                   deb   CVE-2021-4214        Negligible  
+libpng-dev                    1.6.37-3                                   deb   CVE-2019-6129        Negligible  
+libpng16-16                   1.6.37-3                                   deb   CVE-2021-4214        Negligible  
+libpng16-16                   1.6.37-3                                   deb   CVE-2019-6129        Negligible  
+libprocps8                    2:3.3.17-5                    (won't fix)  deb   CVE-2023-4016        Low         
+libpython3.9-minimal          3.9.2-1                       (won't fix)  deb   CVE-2023-24329       High        
+libpython3.9-minimal          3.9.2-1                       (won't fix)  deb   CVE-2022-45061       High        
+libpython3.9-minimal          3.9.2-1                       (won't fix)  deb   CVE-2022-0391        High        
+libpython3.9-minimal          3.9.2-1                       (won't fix)  deb   CVE-2021-3737        High        
+libpython3.9-minimal          3.9.2-1                       (won't fix)  deb   CVE-2020-10735       High        
+libpython3.9-minimal          3.9.2-1                       (won't fix)  deb   CVE-2015-20107       High        
+libpython3.9-minimal          3.9.2-1                       (won't fix)  deb   CVE-2023-40217       Medium      
+libpython3.9-minimal          3.9.2-1                       (won't fix)  deb   CVE-2023-27043       Medium      
+libpython3.9-minimal          3.9.2-1                       (won't fix)  deb   CVE-2021-4189        Medium      
+libpython3.9-minimal          3.9.2-1                       (won't fix)  deb   CVE-2021-3733        Medium      
+libpython3.9-minimal          3.9.2-1                       (won't fix)  deb   CVE-2022-42919       Negligible  
+libpython3.9-minimal          3.9.2-1                                    deb   CVE-2022-37454       Negligible  
+libpython3.9-minimal          3.9.2-1                       (won't fix)  deb   CVE-2021-3426        Negligible  
+libpython3.9-minimal          3.9.2-1                       (won't fix)  deb   CVE-2021-29921       Negligible  
+libpython3.9-minimal          3.9.2-1                                    deb   CVE-2021-28861       Negligible  
+libpython3.9-minimal          3.9.2-1                                    deb   CVE-2020-27619       Negligible  
+libpython3.9-stdlib           3.9.2-1                       (won't fix)  deb   CVE-2023-24329       High        
+libpython3.9-stdlib           3.9.2-1                       (won't fix)  deb   CVE-2022-45061       High        
+libpython3.9-stdlib           3.9.2-1                       (won't fix)  deb   CVE-2022-0391        High        
+libpython3.9-stdlib           3.9.2-1                       (won't fix)  deb   CVE-2021-3737        High        
+libpython3.9-stdlib           3.9.2-1                       (won't fix)  deb   CVE-2020-10735       High        
+libpython3.9-stdlib           3.9.2-1                       (won't fix)  deb   CVE-2015-20107       High        
+libpython3.9-stdlib           3.9.2-1                       (won't fix)  deb   CVE-2023-40217       Medium      
+libpython3.9-stdlib           3.9.2-1                       (won't fix)  deb   CVE-2023-27043       Medium      
+libpython3.9-stdlib           3.9.2-1                       (won't fix)  deb   CVE-2021-4189        Medium      
+libpython3.9-stdlib           3.9.2-1                       (won't fix)  deb   CVE-2021-3733        Medium      
+libpython3.9-stdlib           3.9.2-1                       (won't fix)  deb   CVE-2022-42919       Negligible  
+libpython3.9-stdlib           3.9.2-1                                    deb   CVE-2022-37454       Negligible  
+libpython3.9-stdlib           3.9.2-1                       (won't fix)  deb   CVE-2021-3426        Negligible  
+libpython3.9-stdlib           3.9.2-1                       (won't fix)  deb   CVE-2021-29921       Negligible  
+libpython3.9-stdlib           3.9.2-1                                    deb   CVE-2021-28861       Negligible  
+libpython3.9-stdlib           3.9.2-1                                    deb   CVE-2020-27619       Negligible  
+libsepol1                     3.1-1                         (won't fix)  deb   CVE-2021-36087       Low         
+libsepol1                     3.1-1                         (won't fix)  deb   CVE-2021-36086       Low         
+libsepol1                     3.1-1                         (won't fix)  deb   CVE-2021-36085       Low         
+libsepol1                     3.1-1                         (won't fix)  deb   CVE-2021-36084       Low         
+libsepol1-dev                 3.1-1                         (won't fix)  deb   CVE-2021-36087       Low         
+libsepol1-dev                 3.1-1                         (won't fix)  deb   CVE-2021-36086       Low         
+libsepol1-dev                 3.1-1                         (won't fix)  deb   CVE-2021-36085       Low         
+libsepol1-dev                 3.1-1                         (won't fix)  deb   CVE-2021-36084       Low         
+libsmartcols1                 2.36.1-8+deb11u1                           deb   CVE-2022-0563        Negligible  
+libsqlite3-0                  3.34.1-3                      (won't fix)  deb   CVE-2023-7104        High        
+libsqlite3-0                  3.34.1-3                      (won't fix)  deb   CVE-2021-31239       High        
+libsqlite3-0                  3.34.1-3                                   deb   CVE-2022-35737       Negligible  
+libsqlite3-0                  3.34.1-3                                   deb   CVE-2021-45346       Negligible  
+libsqlite3-0                  3.34.1-3                                   deb   CVE-2021-36690       Negligible  
+libsqlite3-dev                3.34.1-3                      (won't fix)  deb   CVE-2023-7104        High        
+libsqlite3-dev                3.34.1-3                      (won't fix)  deb   CVE-2021-31239       High        
+libsqlite3-dev                3.34.1-3                                   deb   CVE-2022-35737       Negligible  
+libsqlite3-dev                3.34.1-3                                   deb   CVE-2021-45346       Negligible  
+libsqlite3-dev                3.34.1-3                                   deb   CVE-2021-36690       Negligible  
+libss2                        1.46.2-2                      (won't fix)  deb   CVE-2022-1304        High        
+libssh2-1                     1.9.0-2                       (won't fix)  deb   CVE-2020-22218       High        
+libssl-dev                    1.1.1w-0+deb11u1              (won't fix)  deb   CVE-2024-0727        Medium      
+libssl-dev                    1.1.1w-0+deb11u1              (won't fix)  deb   CVE-2023-5678        Medium      
+libssl-dev                    1.1.1w-0+deb11u1                           deb   CVE-2010-0928        Negligible  
+libssl-dev                    1.1.1w-0+deb11u1                           deb   CVE-2007-6755        Negligible  
+libssl1.1                     1.1.1w-0+deb11u1              (won't fix)  deb   CVE-2024-0727        Medium      
+libssl1.1                     1.1.1w-0+deb11u1              (won't fix)  deb   CVE-2023-5678        Medium      
+libssl1.1                     1.1.1w-0+deb11u1                           deb   CVE-2010-0928        Negligible  
+libssl1.1                     1.1.1w-0+deb11u1                           deb   CVE-2007-6755        Negligible  
+libstdc++-10-dev              10.2.1-6                      (won't fix)  deb   CVE-2023-4039        Medium      
+libstdc++6                    10.2.1-6                      (won't fix)  deb   CVE-2023-4039        Medium      
+libsystemd0                   247.3-7+deb11u4               (won't fix)  deb   CVE-2023-50387       High        
+libsystemd0                   247.3-7+deb11u4               (won't fix)  deb   CVE-2023-7008        Medium      
+libsystemd0                   247.3-7+deb11u4                            deb   CVE-2023-31439       Negligible  
+libsystemd0                   247.3-7+deb11u4                            deb   CVE-2023-31438       Negligible  
+libsystemd0                   247.3-7+deb11u4                            deb   CVE-2023-31437       Negligible  
+libsystemd0                   247.3-7+deb11u4                            deb   CVE-2020-13529       Negligible  
+libsystemd0                   247.3-7+deb11u4                            deb   CVE-2013-4392        Negligible  
+libsystemd0                   247.3-7+deb11u4               (won't fix)  deb   CVE-2023-50868       Unknown     
+libtiff-dev                   4.2.0-1+deb11u5               (won't fix)  deb   CVE-2023-52356       High        
+libtiff-dev                   4.2.0-1+deb11u5               (won't fix)  deb   CVE-2023-52355       High        
+libtiff-dev                   4.2.0-1+deb11u5               (won't fix)  deb   CVE-2023-6277        Medium      
+libtiff-dev                   4.2.0-1+deb11u5               (won't fix)  deb   CVE-2023-3618        Medium      
+libtiff-dev                   4.2.0-1+deb11u5               (won't fix)  deb   CVE-2023-3316        Medium      
+libtiff-dev                   4.2.0-1+deb11u5               (won't fix)  deb   CVE-2023-2908        Medium      
+libtiff-dev                   4.2.0-1+deb11u5               (won't fix)  deb   CVE-2023-26966       Medium      
+libtiff-dev                   4.2.0-1+deb11u5               (won't fix)  deb   CVE-2023-26965       Medium      
+libtiff-dev                   4.2.0-1+deb11u5               (won't fix)  deb   CVE-2023-25433       Medium      
+libtiff-dev                   4.2.0-1+deb11u5               (won't fix)  deb   CVE-2022-40090       Medium      
+libtiff-dev                   4.2.0-1+deb11u5                            deb   CVE-2023-6228        Negligible  
+libtiff-dev                   4.2.0-1+deb11u5                            deb   CVE-2023-3164        Negligible  
+libtiff-dev                   4.2.0-1+deb11u5                            deb   CVE-2023-30775       Negligible  
+libtiff-dev                   4.2.0-1+deb11u5                            deb   CVE-2023-1916        Negligible  
+libtiff-dev                   4.2.0-1+deb11u5               (won't fix)  deb   CVE-2022-1210        Negligible  
+libtiff-dev                   4.2.0-1+deb11u5                            deb   CVE-2022-1056        Negligible  
+libtiff-dev                   4.2.0-1+deb11u5                            deb   CVE-2018-10126       Negligible  
+libtiff-dev                   4.2.0-1+deb11u5                            deb   CVE-2017-9117        Negligible  
+libtiff-dev                   4.2.0-1+deb11u5                            deb   CVE-2017-5563        Negligible  
+libtiff-dev                   4.2.0-1+deb11u5                            deb   CVE-2017-17973       Negligible  
+libtiff-dev                   4.2.0-1+deb11u5                            deb   CVE-2017-16232       Negligible  
+libtiff5                      4.2.0-1+deb11u5               (won't fix)  deb   CVE-2023-52356       High        
+libtiff5                      4.2.0-1+deb11u5               (won't fix)  deb   CVE-2023-52355       High        
+libtiff5                      4.2.0-1+deb11u5               (won't fix)  deb   CVE-2023-6277        Medium      
+libtiff5                      4.2.0-1+deb11u5               (won't fix)  deb   CVE-2023-3618        Medium      
+libtiff5                      4.2.0-1+deb11u5               (won't fix)  deb   CVE-2023-3316        Medium      
+libtiff5                      4.2.0-1+deb11u5               (won't fix)  deb   CVE-2023-2908        Medium      
+libtiff5                      4.2.0-1+deb11u5               (won't fix)  deb   CVE-2023-26966       Medium      
+libtiff5                      4.2.0-1+deb11u5               (won't fix)  deb   CVE-2023-26965       Medium      
+libtiff5                      4.2.0-1+deb11u5               (won't fix)  deb   CVE-2023-25433       Medium      
+libtiff5                      4.2.0-1+deb11u5               (won't fix)  deb   CVE-2022-40090       Medium      
+libtiff5                      4.2.0-1+deb11u5                            deb   CVE-2023-6228        Negligible  
+libtiff5                      4.2.0-1+deb11u5                            deb   CVE-2023-3164        Negligible  
+libtiff5                      4.2.0-1+deb11u5                            deb   CVE-2023-30775       Negligible  
+libtiff5                      4.2.0-1+deb11u5                            deb   CVE-2023-1916        Negligible  
+libtiff5                      4.2.0-1+deb11u5               (won't fix)  deb   CVE-2022-1210        Negligible  
+libtiff5                      4.2.0-1+deb11u5                            deb   CVE-2022-1056        Negligible  
+libtiff5                      4.2.0-1+deb11u5                            deb   CVE-2018-10126       Negligible  
+libtiff5                      4.2.0-1+deb11u5                            deb   CVE-2017-9117        Negligible  
+libtiff5                      4.2.0-1+deb11u5                            deb   CVE-2017-5563        Negligible  
+libtiff5                      4.2.0-1+deb11u5                            deb   CVE-2017-17973       Negligible  
+libtiff5                      4.2.0-1+deb11u5                            deb   CVE-2017-16232       Negligible  
+libtiffxx5                    4.2.0-1+deb11u5               (won't fix)  deb   CVE-2023-52356       High        
+libtiffxx5                    4.2.0-1+deb11u5               (won't fix)  deb   CVE-2023-52355       High        
+libtiffxx5                    4.2.0-1+deb11u5               (won't fix)  deb   CVE-2023-6277        Medium      
+libtiffxx5                    4.2.0-1+deb11u5               (won't fix)  deb   CVE-2023-3618        Medium      
+libtiffxx5                    4.2.0-1+deb11u5               (won't fix)  deb   CVE-2023-3316        Medium      
+libtiffxx5                    4.2.0-1+deb11u5               (won't fix)  deb   CVE-2023-2908        Medium      
+libtiffxx5                    4.2.0-1+deb11u5               (won't fix)  deb   CVE-2023-26966       Medium      
+libtiffxx5                    4.2.0-1+deb11u5               (won't fix)  deb   CVE-2023-26965       Medium      
+libtiffxx5                    4.2.0-1+deb11u5               (won't fix)  deb   CVE-2023-25433       Medium      
+libtiffxx5                    4.2.0-1+deb11u5               (won't fix)  deb   CVE-2022-40090       Medium      
+libtiffxx5                    4.2.0-1+deb11u5                            deb   CVE-2023-6228        Negligible  
+libtiffxx5                    4.2.0-1+deb11u5                            deb   CVE-2023-3164        Negligible  
+libtiffxx5                    4.2.0-1+deb11u5                            deb   CVE-2023-30775       Negligible  
+libtiffxx5                    4.2.0-1+deb11u5                            deb   CVE-2023-1916        Negligible  
+libtiffxx5                    4.2.0-1+deb11u5               (won't fix)  deb   CVE-2022-1210        Negligible  
+libtiffxx5                    4.2.0-1+deb11u5                            deb   CVE-2022-1056        Negligible  
+libtiffxx5                    4.2.0-1+deb11u5                            deb   CVE-2018-10126       Negligible  
+libtiffxx5                    4.2.0-1+deb11u5                            deb   CVE-2017-9117        Negligible  
+libtiffxx5                    4.2.0-1+deb11u5                            deb   CVE-2017-5563        Negligible  
+libtiffxx5                    4.2.0-1+deb11u5                            deb   CVE-2017-17973       Negligible  
+libtiffxx5                    4.2.0-1+deb11u5                            deb   CVE-2017-16232       Negligible  
+libtinfo6                     6.2+20201114-2+deb11u2        (won't fix)  deb   CVE-2023-50495       Medium      
+libtinfo6                     6.2+20201114-2+deb11u2        (won't fix)  deb   CVE-2023-45918       Unknown     
+libtsan0                      10.2.1-6                      (won't fix)  deb   CVE-2023-4039        Medium      
+libubsan1                     10.2.1-6                      (won't fix)  deb   CVE-2023-4039        Medium      
+libudev1                      247.3-7+deb11u4               (won't fix)  deb   CVE-2023-50387       High        
+libudev1                      247.3-7+deb11u4               (won't fix)  deb   CVE-2023-7008        Medium      
+libudev1                      247.3-7+deb11u4                            deb   CVE-2023-31439       Negligible  
+libudev1                      247.3-7+deb11u4                            deb   CVE-2023-31438       Negligible  
+libudev1                      247.3-7+deb11u4                            deb   CVE-2023-31437       Negligible  
+libudev1                      247.3-7+deb11u4                            deb   CVE-2020-13529       Negligible  
+libudev1                      247.3-7+deb11u4                            deb   CVE-2013-4392        Negligible  
+libudev1                      247.3-7+deb11u4               (won't fix)  deb   CVE-2023-50868       Unknown     
+libuuid1                      2.36.1-8+deb11u1                           deb   CVE-2022-0563        Negligible  
+libwmf-dev                    0.2.8.4-17                                 deb   CVE-2009-3546        Medium      
+libwmf-dev                    0.2.8.4-17                                 deb   CVE-2007-3996        Medium      
+libwmf-dev                    0.2.8.4-17                                 deb   CVE-2007-3477        Low         
+libwmf-dev                    0.2.8.4-17                                 deb   CVE-2007-3476        Low         
+libwmf0.2-7                   0.2.8.4-17                                 deb   CVE-2009-3546        Medium      
+libwmf0.2-7                   0.2.8.4-17                                 deb   CVE-2007-3996        Medium      
+libwmf0.2-7                   0.2.8.4-17                                 deb   CVE-2007-3477        Low         
+libwmf0.2-7                   0.2.8.4-17                                 deb   CVE-2007-3476        Low         
+libxml2                       2.9.10+dfsg-6.7+deb11u4       (won't fix)  deb   CVE-2024-25062       High        
+libxml2                       2.9.10+dfsg-6.7+deb11u4       (won't fix)  deb   CVE-2022-2309        High        
+libxml2                       2.9.10+dfsg-6.7+deb11u4       (won't fix)  deb   CVE-2023-45322       Medium      
+libxml2                       2.9.10+dfsg-6.7+deb11u4       (won't fix)  deb   CVE-2023-39615       Medium      
+libxml2                       2.9.10+dfsg-6.7+deb11u4       (won't fix)  deb   CVE-2016-3709        Medium      
+libxml2-dev                   2.9.10+dfsg-6.7+deb11u4       (won't fix)  deb   CVE-2024-25062       High        
+libxml2-dev                   2.9.10+dfsg-6.7+deb11u4       (won't fix)  deb   CVE-2022-2309        High        
+libxml2-dev                   2.9.10+dfsg-6.7+deb11u4       (won't fix)  deb   CVE-2023-45322       Medium      
+libxml2-dev                   2.9.10+dfsg-6.7+deb11u4       (won't fix)  deb   CVE-2023-39615       Medium      
+libxml2-dev                   2.9.10+dfsg-6.7+deb11u4       (won't fix)  deb   CVE-2016-3709        Medium      
+libxslt1-dev                  1.1.34-4+deb11u1                           deb   CVE-2015-9019        Negligible  
+libxslt1.1                    1.1.34-4+deb11u1                           deb   CVE-2015-9019        Negligible  
+libzstd1                      1.4.8+dfsg-2.1                (won't fix)  deb   CVE-2022-4899        High        
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-23307       High        
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-21803       High        
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-0841        High        
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-0565        High        
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-6535        High        
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-6270        High        
+linux-libc-dev                5.10.209-2                                 deb   CVE-2022-43945       High        
+linux-libc-dev                5.10.209-2                                 deb   CVE-2022-3566        High        
+linux-libc-dev                5.10.209-2                                 deb   CVE-2022-0500        High        
+linux-libc-dev                5.10.209-2                                 deb   CVE-2021-4204        High        
+linux-libc-dev                5.10.209-2                                 deb   CVE-2021-39686       High        
+linux-libc-dev                5.10.209-2                                 deb   CVE-2021-3864        High        
+linux-libc-dev                5.10.209-2                                 deb   CVE-2021-3847        High        
+linux-libc-dev                5.10.209-2                    (won't fix)  deb   CVE-2020-12362       High        
+linux-libc-dev                5.10.209-2                    (won't fix)  deb   CVE-2019-19814       High        
+linux-libc-dev                5.10.209-2                    (won't fix)  deb   CVE-2019-19449       High        
+linux-libc-dev                5.10.209-2                    (won't fix)  deb   CVE-2013-7445        High        
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-25740       Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-25739       Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-24864       Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-24861       Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-24860       Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-24859       Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-24858       Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-24857       Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-24855       Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-23851       Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-23850       Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-23849       Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-23848       Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-23196       Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-22386       Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-22099       Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-1151        Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-0607        Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-0564        Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-0340        Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-7042        Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-6240        Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52429       Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-47233       Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-4569        Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-4133        Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-4010        Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-37454       Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-3397        Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-31083       Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-31082       Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-1192        Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-0597        Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-0160        Medium      
+linux-libc-dev                5.10.209-2                    (won't fix)  deb   CVE-2022-4543        Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2022-40133       Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2022-38457       Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2022-3567        Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2022-3523        Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2022-3344        Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2022-3114        Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2022-3108        Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2022-1280        Medium      
+linux-libc-dev                5.10.209-2                    (won't fix)  deb   CVE-2022-0480        Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2021-4149        Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2021-4023        Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2021-3669        Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2021-33061       Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2020-36694       Medium      
+linux-libc-dev                5.10.209-2                    (won't fix)  deb   CVE-2020-24504       Medium      
+linux-libc-dev                5.10.209-2                    (won't fix)  deb   CVE-2020-14304       Medium      
+linux-libc-dev                5.10.209-2                    (won't fix)  deb   CVE-2020-12364       Medium      
+linux-libc-dev                5.10.209-2                    (won't fix)  deb   CVE-2020-12363       Medium      
+linux-libc-dev                5.10.209-2                    (won't fix)  deb   CVE-2019-20794       Medium      
+linux-libc-dev                5.10.209-2                    (won't fix)  deb   CVE-2019-16089       Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2019-15794       Medium      
+linux-libc-dev                5.10.209-2                    (won't fix)  deb   CVE-2019-15213       Medium      
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-1075        Low         
+linux-libc-dev                5.10.209-2                    (won't fix)  deb   CVE-2018-12928       Low         
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-6610        Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-4134        Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-3640        Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-31085       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-31081       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-26242       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-23039       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-23003       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-23000       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-22995       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2022-45885       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2022-45884       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2022-44034       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2022-44033       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2022-44032       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2022-41848       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2022-2961        Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2022-27672       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2022-25265       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2022-1247        Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2022-0400        Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2021-3714        Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2021-32078       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2021-26934       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2020-35501       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2020-11725       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2019-19378       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2019-19070       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2019-16234       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2019-16233       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2019-16232       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2019-16231       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2019-16230       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2019-16229       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2019-12456       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2019-12455       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2019-12382       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2019-12381       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2019-12380       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2019-12379       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2019-12378       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2019-11191       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2018-17977       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2018-1121        Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2017-13694       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2017-13693       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2017-0630        Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2016-8660        Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2016-10723       Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2015-2877        Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2014-9900        Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2014-9892        Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2012-4542        Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2011-4917        Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2011-4916        Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2011-4915        Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2010-5321        Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2010-4563        Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2008-4609        Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2008-2544        Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2007-3719        Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2005-3660        Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2004-0230        Negligible  
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-26628       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-26627       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-26625       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-26624       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-26622       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-26615       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-26614       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-26613       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-26610       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-26609       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-26607       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-26606       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-26602       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-26601       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-26600       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-26595       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-26593       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-26589       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-26585       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-26584       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-26583       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-26581       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2024-25741       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52607       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52606       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52605       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52604       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52603       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52602       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52601       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52600       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52599       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52598       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52597       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52596       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52595       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52594       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52593       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52591       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52590       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52589       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52588       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52587       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52586       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52585       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52584       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52583       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52572       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52569       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52561       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52531       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52530       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52517       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52511       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52508       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52498       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52497       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52494       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52493       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52492       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52491       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52489       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52488       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52486       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52485       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52484       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52482       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52481       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52480       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52479       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52476       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52458       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52452       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52435       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2023-52434       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2022-48628       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2022-48626       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2021-47105       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2021-47101       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2021-47094       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2021-47076       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2021-47070       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2021-47037       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2021-47036       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2021-47028       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2021-47014       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2021-46987       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2021-46937       Unknown     
+linux-libc-dev                5.10.209-2                                 deb   CVE-2021-46926       Unknown     
+login                         1:4.8.1-1                     (won't fix)  deb   CVE-2023-4641        Medium      
+login                         1:4.8.1-1                     (won't fix)  deb   CVE-2023-29383       Low         
+login                         1:4.8.1-1                                  deb   CVE-2019-19882       Negligible  
+login                         1:4.8.1-1                                  deb   CVE-2013-4235        Negligible  
+login                         1:4.8.1-1                                  deb   CVE-2007-5686        Negligible  
+logsave                       1.46.2-2                      (won't fix)  deb   CVE-2022-1304        High        
+m4                            1.4.18-5                                   deb   CVE-2008-1688        Negligible  
+m4                            1.4.18-5                                   deb   CVE-2008-1687        Negligible  
+mount                         2.36.1-8+deb11u1                           deb   CVE-2022-0563        Negligible  
+ncurses-base                  6.2+20201114-2+deb11u2        (won't fix)  deb   CVE-2023-50495       Medium      
+ncurses-base                  6.2+20201114-2+deb11u2        (won't fix)  deb   CVE-2023-45918       Unknown     
+ncurses-bin                   6.2+20201114-2+deb11u2        (won't fix)  deb   CVE-2023-50495       Medium      
+ncurses-bin                   6.2+20201114-2+deb11u2        (won't fix)  deb   CVE-2023-45918       Unknown     
+openssh-client                1:8.4p1-5+deb11u3             (won't fix)  deb   CVE-2023-51767       High        
+openssh-client                1:8.4p1-5+deb11u3                          deb   CVE-2021-36368       Negligible  
+openssh-client                1:8.4p1-5+deb11u3                          deb   CVE-2020-15778       Negligible  
+openssh-client                1:8.4p1-5+deb11u3                          deb   CVE-2020-14145       Negligible  
+openssh-client                1:8.4p1-5+deb11u3                          deb   CVE-2019-6110        Negligible  
+openssh-client                1:8.4p1-5+deb11u3                          deb   CVE-2018-15919       Negligible  
+openssh-client                1:8.4p1-5+deb11u3                          deb   CVE-2016-20012       Negligible  
+openssh-client                1:8.4p1-5+deb11u3                          deb   CVE-2008-3234        Negligible  
+openssh-client                1:8.4p1-5+deb11u3                          deb   CVE-2007-2768        Negligible  
+openssh-client                1:8.4p1-5+deb11u3                          deb   CVE-2007-2243        Negligible  
+openssl                       1.1.1w-0+deb11u1              (won't fix)  deb   CVE-2024-0727        Medium      
+openssl                       1.1.1w-0+deb11u1              (won't fix)  deb   CVE-2023-5678        Medium      
+openssl                       1.1.1w-0+deb11u1                           deb   CVE-2010-0928        Negligible  
+openssl                       1.1.1w-0+deb11u1                           deb   CVE-2007-6755        Negligible  
+passwd                        1:4.8.1-1                     (won't fix)  deb   CVE-2023-4641        Medium      
+passwd                        1:4.8.1-1                     (won't fix)  deb   CVE-2023-29383       Low         
+passwd                        1:4.8.1-1                                  deb   CVE-2019-19882       Negligible  
+passwd                        1:4.8.1-1                                  deb   CVE-2013-4235        Negligible  
+passwd                        1:4.8.1-1                                  deb   CVE-2007-5686        Negligible  
+patch                         2.7.6-7                                    deb   CVE-2021-45261       Negligible  
+patch                         2.7.6-7                                    deb   CVE-2018-6952        Negligible  
+patch                         2.7.6-7                                    deb   CVE-2018-6951        Negligible  
+patch                         2.7.6-7                                    deb   CVE-2010-4651        Negligible  
+perl                          5.32.1-4+deb11u3              (won't fix)  deb   CVE-2023-31484       High        
+perl                          5.32.1-4+deb11u3              (won't fix)  deb   CVE-2020-16156       High        
+perl                          5.32.1-4+deb11u3                           deb   CVE-2023-31486       Negligible  
+perl                          5.32.1-4+deb11u3                           deb   CVE-2011-4116        Negligible  
+perl-base                     5.32.1-4+deb11u3              (won't fix)  deb   CVE-2023-31484       High        
+perl-base                     5.32.1-4+deb11u3              (won't fix)  deb   CVE-2020-16156       High        
+perl-base                     5.32.1-4+deb11u3                           deb   CVE-2023-31486       Negligible  
+perl-base                     5.32.1-4+deb11u3                           deb   CVE-2011-4116        Negligible  
+perl-modules-5.32             5.32.1-4+deb11u3              (won't fix)  deb   CVE-2023-31484       High        
+perl-modules-5.32             5.32.1-4+deb11u3              (won't fix)  deb   CVE-2020-16156       High        
+perl-modules-5.32             5.32.1-4+deb11u3                           deb   CVE-2023-31486       Negligible  
+perl-modules-5.32             5.32.1-4+deb11u3                           deb   CVE-2011-4116        Negligible  
+procps                        2:3.3.17-5                    (won't fix)  deb   CVE-2023-4016        Low         
+python3.9                     3.9.2-1                       (won't fix)  deb   CVE-2023-24329       High        
+python3.9                     3.9.2-1                       (won't fix)  deb   CVE-2022-45061       High        
+python3.9                     3.9.2-1                       (won't fix)  deb   CVE-2022-0391        High        
+python3.9                     3.9.2-1                       (won't fix)  deb   CVE-2021-3737        High        
+python3.9                     3.9.2-1                       (won't fix)  deb   CVE-2020-10735       High        
+python3.9                     3.9.2-1                       (won't fix)  deb   CVE-2015-20107       High        
+python3.9                     3.9.2-1                       (won't fix)  deb   CVE-2023-40217       Medium      
+python3.9                     3.9.2-1                       (won't fix)  deb   CVE-2023-27043       Medium      
+python3.9                     3.9.2-1                       (won't fix)  deb   CVE-2021-4189        Medium      
+python3.9                     3.9.2-1                       (won't fix)  deb   CVE-2021-3733        Medium      
+python3.9                     3.9.2-1                       (won't fix)  deb   CVE-2022-42919       Negligible  
+python3.9                     3.9.2-1                                    deb   CVE-2022-37454       Negligible  
+python3.9                     3.9.2-1                       (won't fix)  deb   CVE-2021-3426        Negligible  
+python3.9                     3.9.2-1                       (won't fix)  deb   CVE-2021-29921       Negligible  
+python3.9                     3.9.2-1                                    deb   CVE-2021-28861       Negligible  
+python3.9                     3.9.2-1                                    deb   CVE-2020-27619       Negligible  
+python3.9-minimal             3.9.2-1                       (won't fix)  deb   CVE-2023-24329       High        
+python3.9-minimal             3.9.2-1                       (won't fix)  deb   CVE-2022-45061       High        
+python3.9-minimal             3.9.2-1                       (won't fix)  deb   CVE-2022-0391        High        
+python3.9-minimal             3.9.2-1                       (won't fix)  deb   CVE-2021-3737        High        
+python3.9-minimal             3.9.2-1                       (won't fix)  deb   CVE-2020-10735       High        
+python3.9-minimal             3.9.2-1                       (won't fix)  deb   CVE-2015-20107       High        
+python3.9-minimal             3.9.2-1                       (won't fix)  deb   CVE-2023-40217       Medium      
+python3.9-minimal             3.9.2-1                       (won't fix)  deb   CVE-2023-27043       Medium      
+python3.9-minimal             3.9.2-1                       (won't fix)  deb   CVE-2021-4189        Medium      
+python3.9-minimal             3.9.2-1                       (won't fix)  deb   CVE-2021-3733        Medium      
+python3.9-minimal             3.9.2-1                       (won't fix)  deb   CVE-2022-42919       Negligible  
+python3.9-minimal             3.9.2-1                                    deb   CVE-2022-37454       Negligible  
+python3.9-minimal             3.9.2-1                       (won't fix)  deb   CVE-2021-3426        Negligible  
+python3.9-minimal             3.9.2-1                       (won't fix)  deb   CVE-2021-29921       Negligible  
+python3.9-minimal             3.9.2-1                                    deb   CVE-2021-28861       Negligible  
+python3.9-minimal             3.9.2-1                                    deb   CVE-2020-27619       Negligible  
+tar                           1.34+dfsg-1+deb11u1                        deb   CVE-2005-2541        Negligible  
+unzip                         6.0-26+deb11u1                             deb   CVE-2021-4217        Negligible  
+util-linux                    2.36.1-8+deb11u1                           deb   CVE-2022-0563        Negligible  
+uuid-dev                      2.36.1-8+deb11u1                           deb   CVE-2022-0563        Negligible  
+wget                          1.21-1+deb11u1                (won't fix)  deb   CVE-2021-31879       Medium      
+zlib1g                        1:1.2.11.dfsg-2+deb11u2       (won't fix)  deb   CVE-2023-45853       Critical    
+zlib1g-dev                    1:1.2.11.dfsg-2+deb11u2       (won't fix)  deb   CVE-2023-45853       Critical
+
+
+## chainguard-node-server
+
+ ✔ Vulnerability DB                [no update available]  
+   ├── ⠹ Packages                        [372 packages]  
+   │     ├── ⠹ Cargo auditable binary        cataloger                       
+ ✔ Cataloged contents              f8711fb72e3bad1d48e3079e2321bc1a5918724890a0352c20c6a6873f86  
+   ├── ✔ Packages                        [370 packages]  
+   ├── ✔ File digests                    [1,673 files]  
+   ├── ✔ File metadata                   [1,673 locations]  
+   └── ✔ Executables                     [63 executables]  
+ ✔ Scanned for vulnerabilities     [3 vulnerability matches]  
+   ├── by severity: 0 critical, 0 high, 3 medium, 0 low, 0 negligible
+   └── by status:   3 fixed, 0 not-fixed, 0 ignored 
+NAME          INSTALLED  FIXED-IN  TYPE  VULNERABILITY        SEVERITY 
+jsonwebtoken  8.5.1      9.0.0     npm   GHSA-qwph-4952-7xr6  Medium    
+jsonwebtoken  8.5.1      9.0.0     npm   GHSA-hjrf-2m68-5959  Medium    
+jsonwebtoken  8.5.1      9.0.0     npm   GHSA-8cf7-32gw-wr33  Medium


### PR DESCRIPTION
Compared Base image vulns vs Chainguard Image using Grype, and have made a note of the results.