### PR TITLE
powersj scan results of telegraf contianer

### DIFF
--- a/vulnz/powersj.md
+++ b/vulnz/powersj.md
@@ -1,0 +1,164 @@
+## telegraf-debian
+
+❯ grype powersj-telegraf
+ ✔ Vulnerability DB                [no update available]
+ ✔ Loaded image                                                                           powersj-telegraf:latest
+ ✔ Parsed image                           sha256:e69db80dafc69e857458de49ab47a236ff7887c66f9ced9b515409e0d84fff9a
+ ✔ Cataloged contents                            2df9c5313a04db89ce20efbd61206f39d199cf52ad789f5eff6360184b9378f8
+   ├── ✔ Packages                        [598 packages]
+   ├── ✔ File digests                    [7,696 files]
+   ├── ✔ File metadata                   [7,696 locations]
+   └── ✔ Executables                     [867 executables]
+ ✔ Scanned for vulnerabilities     [130 vulnerability matches]
+   ├── by severity: 4 critical, 6 high, 17 medium, 5 low, 73 negligible (25 unknown)
+   └── by status:   1 fixed, 129 not-fixed, 0 ignored
+NAME                      INSTALLED              FIXED-IN     TYPE       VULNERABILITY        SEVERITY
+apt                       2.6.1                               deb        CVE-2011-3374        Negligible
+bsdutils                  1:2.38.1-5+deb12u1                  deb        CVE-2022-0563        Negligible
+coreutils                 9.1-1                  (won't fix)  deb        CVE-2016-2781        Low
+coreutils                 9.1-1                               deb        CVE-2017-18018       Negligible
+curl                      7.88.1-10+deb12u6                   deb        CVE-2024-2379        Negligible
+curl                      7.88.1-10+deb12u6                   deb        CVE-2024-7264        Unknown
+dirmngr                   2.2.40-1.1                          deb        CVE-2022-3219        Negligible
+gcc-12-base               12.2.0-14              (won't fix)  deb        CVE-2023-4039        Medium
+gcc-12-base               12.2.0-14                           deb        CVE-2022-27943       Negligible
+github.com/docker/docker  v25.0.5+incompatible   26.1.4       go-module  GHSA-v23v-6jw2-98fq  Critical
+gnupg                     2.2.40-1.1                          deb        CVE-2022-3219        Negligible
+gnupg-l10n                2.2.40-1.1                          deb        CVE-2022-3219        Negligible
+gnupg-utils               2.2.40-1.1                          deb        CVE-2022-3219        Negligible
+gpg                       2.2.40-1.1                          deb        CVE-2022-3219        Negligible
+gpg-agent                 2.2.40-1.1                          deb        CVE-2022-3219        Negligible
+gpg-wks-client            2.2.40-1.1                          deb        CVE-2022-3219        Negligible
+gpg-wks-server            2.2.40-1.1                          deb        CVE-2022-3219        Negligible
+gpgconf                   2.2.40-1.1                          deb        CVE-2022-3219        Negligible
+gpgsm                     2.2.40-1.1                          deb        CVE-2022-3219        Negligible
+gpgv                      2.2.40-1.1                          deb        CVE-2022-3219        Negligible
+libapt-pkg6.0             2.6.1                               deb        CVE-2011-3374        Negligible
+libblkid1                 2.38.1-5+deb12u1                    deb        CVE-2022-0563        Negligible
+libc-bin                  2.36-9+deb12u7                      deb        CVE-2019-9192        Negligible
+libc-bin                  2.36-9+deb12u7                      deb        CVE-2019-1010025     Negligible
+libc-bin                  2.36-9+deb12u7                      deb        CVE-2019-1010024     Negligible
+libc-bin                  2.36-9+deb12u7                      deb        CVE-2019-1010023     Negligible
+libc-bin                  2.36-9+deb12u7                      deb        CVE-2019-1010022     Negligible
+libc-bin                  2.36-9+deb12u7                      deb        CVE-2018-20796       Negligible
+libc-bin                  2.36-9+deb12u7                      deb        CVE-2010-4756        Negligible
+libc6                     2.36-9+deb12u7                      deb        CVE-2019-9192        Negligible
+libc6                     2.36-9+deb12u7                      deb        CVE-2019-1010025     Negligible
+libc6                     2.36-9+deb12u7                      deb        CVE-2019-1010024     Negligible
+libc6                     2.36-9+deb12u7                      deb        CVE-2019-1010023     Negligible
+libc6                     2.36-9+deb12u7                      deb        CVE-2019-1010022     Negligible
+libc6                     2.36-9+deb12u7                      deb        CVE-2018-20796       Negligible
+libc6                     2.36-9+deb12u7                      deb        CVE-2010-4756        Negligible
+libcurl4                  7.88.1-10+deb12u6                   deb        CVE-2024-2379        Negligible
+libcurl4                  7.88.1-10+deb12u6                   deb        CVE-2024-7264        Unknown
+libgcc-s1                 12.2.0-14              (won't fix)  deb        CVE-2023-4039        Medium
+libgcc-s1                 12.2.0-14                           deb        CVE-2022-27943       Negligible
+libgcrypt20               1.10.1-3               (won't fix)  deb        CVE-2024-2236        Medium
+libgcrypt20               1.10.1-3                            deb        CVE-2018-6829        Negligible
+libgnutls30               3.7.9-2+deb12u3                     deb        CVE-2011-3389        Negligible
+libgssapi-krb5-2          1.20.1-2+deb12u2                    deb        CVE-2018-5709        Negligible
+libgssapi-krb5-2          1.20.1-2+deb12u2       (won't fix)  deb        CVE-2024-26462       Unknown
+libgssapi-krb5-2          1.20.1-2+deb12u2       (won't fix)  deb        CVE-2024-26461       Unknown
+libgssapi-krb5-2          1.20.1-2+deb12u2       (won't fix)  deb        CVE-2024-26458       Unknown
+libk5crypto3              1.20.1-2+deb12u2                    deb        CVE-2018-5709        Negligible
+libk5crypto3              1.20.1-2+deb12u2       (won't fix)  deb        CVE-2024-26462       Unknown
+libk5crypto3              1.20.1-2+deb12u2       (won't fix)  deb        CVE-2024-26461       Unknown
+libk5crypto3              1.20.1-2+deb12u2       (won't fix)  deb        CVE-2024-26458       Unknown
+libkrb5-3                 1.20.1-2+deb12u2                    deb        CVE-2018-5709        Negligible
+libkrb5-3                 1.20.1-2+deb12u2       (won't fix)  deb        CVE-2024-26462       Unknown
+libkrb5-3                 1.20.1-2+deb12u2       (won't fix)  deb        CVE-2024-26461       Unknown
+libkrb5-3                 1.20.1-2+deb12u2       (won't fix)  deb        CVE-2024-26458       Unknown
+libkrb5support0           1.20.1-2+deb12u2                    deb        CVE-2018-5709        Negligible
+libkrb5support0           1.20.1-2+deb12u2       (won't fix)  deb        CVE-2024-26462       Unknown
+libkrb5support0           1.20.1-2+deb12u2       (won't fix)  deb        CVE-2024-26461       Unknown
+libkrb5support0           1.20.1-2+deb12u2       (won't fix)  deb        CVE-2024-26458       Unknown
+libldap-2.5-0             2.5.13+dfsg-5          (won't fix)  deb        CVE-2023-2953        High
+libldap-2.5-0             2.5.13+dfsg-5                       deb        CVE-2020-15719       Negligible
+libldap-2.5-0             2.5.13+dfsg-5                       deb        CVE-2017-17740       Negligible
+libldap-2.5-0             2.5.13+dfsg-5                       deb        CVE-2017-14159       Negligible
+libldap-2.5-0             2.5.13+dfsg-5                       deb        CVE-2015-3276        Negligible
+libmount1                 2.38.1-5+deb12u1                    deb        CVE-2022-0563        Negligible
+libncursesw6              6.4-4                  (won't fix)  deb        CVE-2023-50495       Medium
+libncursesw6              6.4-4                  (won't fix)  deb        CVE-2023-45918       Unknown
+libnghttp2-14             1.52.0-1+deb12u1                    deb        CVE-2024-28182       Medium
+libpam-modules            1.5.2-6+deb12u1        (won't fix)  deb        CVE-2024-22365       Medium
+libpam-modules-bin        1.5.2-6+deb12u1        (won't fix)  deb        CVE-2024-22365       Medium
+libpam-runtime            1.5.2-6+deb12u1        (won't fix)  deb        CVE-2024-22365       Medium
+libpam0g                  1.5.2-6+deb12u1        (won't fix)  deb        CVE-2024-22365       Medium
+libperl5.36               5.36.0-7+deb12u1       (won't fix)  deb        CVE-2023-31484       High
+libperl5.36               5.36.0-7+deb12u1                    deb        CVE-2023-31486       Negligible
+libperl5.36               5.36.0-7+deb12u1                    deb        CVE-2011-4116        Negligible
+libproc2-0                2:4.0.2-3              (won't fix)  deb        CVE-2023-4016        Low
+libsmartcols1             2.38.1-5+deb12u1                    deb        CVE-2022-0563        Negligible
+libsqlite3-0              3.40.1-2               (won't fix)  deb        CVE-2023-7104        High
+libsqlite3-0              3.40.1-2               (won't fix)  deb        CVE-2024-0232        Medium
+libsqlite3-0              3.40.1-2                            deb        CVE-2021-45346       Negligible
+libssl3                   3.0.13-1~deb12u1       (won't fix)  deb        CVE-2024-5535        Critical
+libssl3                   3.0.13-1~deb12u1       (won't fix)  deb        CVE-2024-4741        Unknown
+libssl3                   3.0.13-1~deb12u1       (won't fix)  deb        CVE-2024-4603        Unknown
+libssl3                   3.0.13-1~deb12u1       (won't fix)  deb        CVE-2024-2511        Unknown
+libstdc++6                12.2.0-14              (won't fix)  deb        CVE-2023-4039        Medium
+libstdc++6                12.2.0-14                           deb        CVE-2022-27943       Negligible
+libsystemd0               252.26-1~deb12u2                    deb        CVE-2023-31439       Negligible
+libsystemd0               252.26-1~deb12u2                    deb        CVE-2023-31438       Negligible
+libsystemd0               252.26-1~deb12u2                    deb        CVE-2023-31437       Negligible
+libsystemd0               252.26-1~deb12u2                    deb        CVE-2013-4392        Negligible
+libtinfo6                 6.4-4                  (won't fix)  deb        CVE-2023-50495       Medium
+libtinfo6                 6.4-4                  (won't fix)  deb        CVE-2023-45918       Unknown
+libudev1                  252.26-1~deb12u2                    deb        CVE-2023-31439       Negligible
+libudev1                  252.26-1~deb12u2                    deb        CVE-2023-31438       Negligible
+libudev1                  252.26-1~deb12u2                    deb        CVE-2023-31437       Negligible
+libudev1                  252.26-1~deb12u2                    deb        CVE-2013-4392        Negligible
+libuuid1                  2.38.1-5+deb12u1                    deb        CVE-2022-0563        Negligible
+login                     1:4.13+dfsg1-1+b1      (won't fix)  deb        CVE-2023-4641        Medium
+login                     1:4.13+dfsg1-1+b1      (won't fix)  deb        CVE-2023-29383       Low
+login                     1:4.13+dfsg1-1+b1                   deb        CVE-2019-19882       Negligible
+login                     1:4.13+dfsg1-1+b1                   deb        CVE-2007-5686        Negligible
+mount                     2.38.1-5+deb12u1                    deb        CVE-2022-0563        Negligible
+ncurses-base              6.4-4                  (won't fix)  deb        CVE-2023-50495       Medium
+ncurses-base              6.4-4                  (won't fix)  deb        CVE-2023-45918       Unknown
+ncurses-bin               6.4-4                  (won't fix)  deb        CVE-2023-50495       Medium
+ncurses-bin               6.4-4                  (won't fix)  deb        CVE-2023-45918       Unknown
+openssl                   3.0.13-1~deb12u1       (won't fix)  deb        CVE-2024-5535        Critical
+openssl                   3.0.13-1~deb12u1       (won't fix)  deb        CVE-2024-4741        Unknown
+openssl                   3.0.13-1~deb12u1       (won't fix)  deb        CVE-2024-4603        Unknown
+openssl                   3.0.13-1~deb12u1       (won't fix)  deb        CVE-2024-2511        Unknown
+passwd                    1:4.13+dfsg1-1+b1      (won't fix)  deb        CVE-2023-4641        Medium
+passwd                    1:4.13+dfsg1-1+b1      (won't fix)  deb        CVE-2023-29383       Low
+passwd                    1:4.13+dfsg1-1+b1                   deb        CVE-2019-19882       Negligible
+passwd                    1:4.13+dfsg1-1+b1                   deb        CVE-2007-5686        Negligible
+perl                      5.36.0-7+deb12u1       (won't fix)  deb        CVE-2023-31484       High
+perl                      5.36.0-7+deb12u1                    deb        CVE-2023-31486       Negligible
+perl                      5.36.0-7+deb12u1                    deb        CVE-2011-4116        Negligible
+perl-base                 5.36.0-7+deb12u1       (won't fix)  deb        CVE-2023-31484       High
+perl-base                 5.36.0-7+deb12u1                    deb        CVE-2023-31486       Negligible
+perl-base                 5.36.0-7+deb12u1                    deb        CVE-2011-4116        Negligible
+perl-modules-5.36         5.36.0-7+deb12u1       (won't fix)  deb        CVE-2023-31484       High
+perl-modules-5.36         5.36.0-7+deb12u1                    deb        CVE-2023-31486       Negligible
+perl-modules-5.36         5.36.0-7+deb12u1                    deb        CVE-2011-4116        Negligible
+procps                    2:4.0.2-3              (won't fix)  deb        CVE-2023-4016        Low
+tar                       1.34+dfsg-1.2+deb12u1               deb        CVE-2005-2541        Negligible
+util-linux                2.38.1-5+deb12u1                    deb        CVE-2022-0563        Negligible
+util-linux-extra          2.38.1-5+deb12u1                    deb        CVE-2022-0563        Negligible
+wget                      1.21.3-1+b2            (won't fix)  deb        CVE-2021-31879       Medium
+wget                      1.21.3-1+b2            (won't fix)  deb        CVE-2024-38428       Unknown
+zlib1g                    1:1.2.13.dfsg-1        (won't fix)  deb        CVE-2023-45853       Critical
+
+## telegraf-chainguard
+
+$ grype powersj-chainguard
+ ✔ Vulnerability DB                [no update available]
+ ✔ Loaded image                                                                                 powersj-cg:latest
+ ✔ Parsed image                           sha256:c9849cf6bb3e835f10da5586224e0b30c1407d9b497b37605966c3f71b2bed47
+ ✔ Cataloged contents                            038c5c134010ac05be8e642daa6c1785c574e3b15db4540ddb6256f15669bc26
+   ├── ✔ Packages                        [451 packages]
+   ├── ✔ File digests                    [22 files]
+   ├── ✔ File metadata                   [22 locations]
+   └── ✔ Executables                     [1 executables]
+ ✔ Scanned for vulnerabilities     [3 vulnerability matches]
+   ├── by severity: 2 critical, 0 high, 0 medium, 0 low, 0 negligible (1 unknown)
+   └── by status:   3 fixed, 0 not-fixed, 0 ignored
+NAME                      INSTALLED             FIXED-IN   TYPE       VULNERABILITY        SEVERITY
+github.com/docker/docker  v25.0.5+incompatible  26.1.4     go-module  GHSA-v23v-6jw2-98fq  Critical
+telegraf-1.31             1.31.2-r0             1.31.2-r1  apk        CVE-2024-41110       Critical
+telegraf-1.31             1.31.2-r0             1.31.2-r1  apk        GHSA-v23v-6jw2-98fq  Unknown


### PR DESCRIPTION
This was produces as part of the final project for the Chainguard Vulnerability Management-Certification. I used the Telegraf Official Docker container with a custom Telegraf config and scanned the container. That container is based off of Debian.

Then I switched to using the Chainguard Telegraf contianer. While I was hoping to produce an contianer with smartmontools installed, however, it seems wolfi does not have that package yet, so I could not multi-stage build. But this clearly shows the removal of the OS CVEs and only the potential Go binary CVEs remain.