### PR TITLE
guacamole-server vulnz for pete-the-great

### DIFF
--- a/vulnz/pete-the-great.md
+++ b/vulnz/pete-the-great.md
@@ -1,31 +1,33 @@
 ## container-guacamole-server
-NAME         INSTALLED   FIXED-IN        TYPE  VULNERABILITY   SEVERITY 
-avahi-libs   0.8-r13     0.9             apk   CVE-2023-38469  Medium    
-avahi-libs   0.8-r13     0.9             apk   CVE-2023-38470  Medium    
-avahi-libs   0.8-r13     0.9             apk   CVE-2023-38471  Medium    
-avahi-libs   0.8-r13     0.9             apk   CVE-2023-38472  Medium    
-avahi-libs   0.8-r13     0.9             apk   CVE-2023-38473  Medium    
-cups-libs    2.4.9-r0                    apk   CVE-2018-6553   High      
-ghostscript  10.04.0-r0                  apk   CVE-2023-38560  Medium    
-glib         2.76.6-r0   2.78.5, 2.80.1  apk   CVE-2024-34397  Unknown   
-libcrypto3   3.1.7-r0    3.1.7-r1        apk   CVE-2024-9143   Unknown   
-libssl3      3.1.7-r0    3.1.7-r1        apk   CVE-2024-9143   Unknown   
-linux-pam    1.5.2-r10   1.6.0           apk   CVE-2024-22365  Medium    
-pixman       0.42.2-r1                   apk   CVE-2023-37769  Medium    
-tiff         4.5.1-r0                    apk   CVE-2015-7313   Medium    
-tiff         4.5.1-r0                    apk   CVE-2023-52356  High      
-tiff         4.5.1-r0                    apk   CVE-2023-6228   Low       
-tiff         4.5.1-r0                    apk   CVE-2023-6277   Medium    
-tiff         4.5.1-r0                    apk   CVE-2024-7006   High      
-tiff         4.5.1-r0    4.6.0           apk   CVE-2023-3164   Medium    
-tiff         4.5.1-r0    4.6.0           apk   CVE-2023-40745  Medium    
-tiff         4.5.1-r0    4.6.0           apk   CVE-2023-41175  Medium    
-tiff         4.5.1-r0    4.6.0           apk   CVE-2023-52355  High      
+| NAME | INSTALLED | FIXED-IN | TYPE | VULNERABILITY | SEVERITY |
+| ---- | --------- | -------- | ---- | ------------- | -------- |
+| avahi-libs | 0.8-r13    |  0.9           | apk  | CVE-2023-38469 | Medium |
+| avahi-libs | 0.8-r13    |   0.9         | apk  | CVE-2023-38470 | Medium |  
+| avahi-libs | 0.8-r13    |   0.9         | apk  | CVE-2023-38471 | Medium |  
+| avahi-libs | 0.8-r13    |   0.9         | apk  | CVE-2023-38472 | Medium |  
+| avahi-libs | 0.8-r13    |  0.9          | apk  | CVE-2023-38473 | Medium |  
+| cups-libs  | 2.4.9-r0   |                | apk  | CVE-2018-6553 | High |  
+| ghostscript| 10.04.0-r0 |                | apk  | CVE-2023-38560 | Medium |    
+| glib       | 2.76.6-r0  | 2.78.5, 2.80.1  | apk  | CVE-2024-34397 | Unknown |  
+| libcrypto3 | 3.1.7-r0   | 3.1.7-r1       | apk  | CVE-2024-9143 |  Unknown | 
+| libssl3    | 3.1.7-r0   | 3.1.7-r1       | apk  | CVE-2024-9143 |  Unknown |
+| linux-pam  | 1.5.2-r10  | 1.6.0          | apk  | CVE-2024-22365 |  Medium |   
+| pixman     | 0.42.2-r1  |                | apk  | CVE-2023-37769 | Medium  |  
+| tiff       | 4.5.1-r0   |                | apk  | CVE-2015-7313 |   Medium |   
+| tiff       | 4.5.1-r0   |                | apk  | CVE-2023-52356 | High    | 
+| tiff       | 4.5.1-r0   |                | apk  | CVE-2023-6228 |  Low     |
+| tiff       | 4.5.1-r0   |                | apk  | CVE-2023-6277 |  Medium  |
+| tiff       | 4.5.1-r0   |                | apk  | CVE-2024-7006 |  High    |
+| tiff       | 4.5.1-r0   | 4.6.0          | apk  | CVE-2023-3164 |   Medium | 
+| tiff       | 4.5.1-r0   | 4.6.0          | apk  | CVE-2023-40745 | Medium  |
+| tiff       | 4.5.1-r0   | 4.6.0          | apk  | CVE-2023-41175 | Medium  |
+| tiff       | 4.5.1-r0   | 4.6.0          | apk  | CVE-2023-52355 |  High   | 
 ## chainguard-guacamole-server
-NAME            INSTALLED  FIXED-IN  TYPE            VULNERABILITY   SEVERITY 
-cups            v2.4.11              UnknownPackage  CVE-2018-6553   High      
-libavcodec60    7.0-r0               apk             CVE-2024-32230  High      
-libavformat60   7.0-r0               apk             CVE-2024-32230  High      
-libavutil58     7.0-r0               apk             CVE-2024-32230  High      
-libswresample4  7.0-r0               apk             CVE-2024-32230  High      
-libswscale7     7.0-r0               apk             CVE-2024-32230  High      
+| NAME | INSTALLED | FIXED-IN | TYPE | VULNERABILITY | SEVERITY |
+| ---- | --------- | -------- | ---- | ------------- | -------- |
+|cups            | v2.4.11  |           | UnknownPackage | CVE-2018-6553  | High |     
+|libavcodec60    | 7.0-r0   |           | apk            | CVE-2024-32230 | High |     
+|libavformat60   | 7.0-r0   |           | apk            | CVE-2024-32230 | High |     
+|libavutil58     | 7.0-r0   |           | apk            | CVE-2024-32230 | High |     
+|libswresample4  | 7.0-r0   |           | apk            | CVE-2024-32230 | High |     
+|libswscale7     | 7.0-r0   |           | apk            | CVE-2024-32230 | High |     

--- a/vulnz/pete-the-great.md
+++ b/vulnz/pete-the-great.md
@@ -1,0 +1,31 @@
+## container-guacamole-server
+NAME         INSTALLED   FIXED-IN        TYPE  VULNERABILITY   SEVERITY 
+avahi-libs   0.8-r13     0.9             apk   CVE-2023-38469  Medium    
+avahi-libs   0.8-r13     0.9             apk   CVE-2023-38470  Medium    
+avahi-libs   0.8-r13     0.9             apk   CVE-2023-38471  Medium    
+avahi-libs   0.8-r13     0.9             apk   CVE-2023-38472  Medium    
+avahi-libs   0.8-r13     0.9             apk   CVE-2023-38473  Medium    
+cups-libs    2.4.9-r0                    apk   CVE-2018-6553   High      
+ghostscript  10.04.0-r0                  apk   CVE-2023-38560  Medium    
+glib         2.76.6-r0   2.78.5, 2.80.1  apk   CVE-2024-34397  Unknown   
+libcrypto3   3.1.7-r0    3.1.7-r1        apk   CVE-2024-9143   Unknown   
+libssl3      3.1.7-r0    3.1.7-r1        apk   CVE-2024-9143   Unknown   
+linux-pam    1.5.2-r10   1.6.0           apk   CVE-2024-22365  Medium    
+pixman       0.42.2-r1                   apk   CVE-2023-37769  Medium    
+tiff         4.5.1-r0                    apk   CVE-2015-7313   Medium    
+tiff         4.5.1-r0                    apk   CVE-2023-52356  High      
+tiff         4.5.1-r0                    apk   CVE-2023-6228   Low       
+tiff         4.5.1-r0                    apk   CVE-2023-6277   Medium    
+tiff         4.5.1-r0                    apk   CVE-2024-7006   High      
+tiff         4.5.1-r0    4.6.0           apk   CVE-2023-3164   Medium    
+tiff         4.5.1-r0    4.6.0           apk   CVE-2023-40745  Medium    
+tiff         4.5.1-r0    4.6.0           apk   CVE-2023-41175  Medium    
+tiff         4.5.1-r0    4.6.0           apk   CVE-2023-52355  High      
+## chainguard-guacamole-server
+NAME            INSTALLED  FIXED-IN  TYPE            VULNERABILITY   SEVERITY 
+cups            v2.4.11              UnknownPackage  CVE-2018-6553   High      
+libavcodec60    7.0-r0               apk             CVE-2024-32230  High      
+libavformat60   7.0-r0               apk             CVE-2024-32230  High      
+libavutil58     7.0-r0               apk             CVE-2024-32230  High      
+libswresample4  7.0-r0               apk             CVE-2024-32230  High      
+libswscale7     7.0-r0               apk             CVE-2024-32230  High      


### PR DESCRIPTION
This is the vulnerability difference between the current Dockerfile from the official guacamole-server repository vs the Chainguard image.  