### PR TITLE
adding project assignment in vulnz, please review

### DIFF
--- a/vulnz/Sir-gits-a-lot.md
+++ b/vulnz/Sir-gits-a-lot.md
@@ -1,0 +1,85 @@
+# Chainguard go and alpine Comparison using Grype
+
+This is an example comparison of using golang alpine and Chainguard based images performed on Nov 18, 2024 for the Chainguard course "Painless Vulnerability Management" Final Project Option 1 (Technical).
+
+The results show that Alpine has 12 vulnerabilities and Chainuard as 0 vulerabilites.
+
+1. `alpine` (12 (2 fixed, 10 not-fixed) vulnerabilites)
+
+```
+ ✔ Scanned for vulnerabilities     [12 vulnerability matches]  
+   ├── by severity: 2 critical, 2 high, 6 medium, 0 low, 0 negligible (2 unknown)
+   └── by status:   2 fixed, 10 not-fixed, 0 ignored 
+```
+
+2. `FROM cgr.dev/chainguard/go:latest` (0 vulnerabilites0)
+
+```
+ ✔ Scanned for vulnerabilities     [0 vulnerability matches]  
+   ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
+   └── by status:   0 fixed, 0 not-fixed, 0 ignored 
+No vulnerabilities found
+```
+
+### Docker build with golang-alpine (Step 3: Build the Image)
+
+```
+docker build . -t container-golang-server
+```
+
+
+### Grype Vulnerabilities with Alpine (Step 4: Scan official image with Grype)
+
+```
+grype golang-server
+ ✔ Loaded image                                                                                           golang-server:latest
+ ✔ Parsed image                                        sha256:5f52e5d23c2bb97e6b9c273a00733e4a1a3f8aa9c5c6089faedb845d42538512
+ ✔ Cataloged contents                                         bca7bc753089415beb1e286935d11e9c149d6bab07227eaaa09cbbde35b23ada
+   ├── ✔ Packages                        [16 packages]  
+   ├── ✔ File digests                    [78 files]  
+   ├── ✔ File metadata                   [78 locations]  
+   └── ✔ Executables                     [17 executables]  
+ ✔ Scanned for vulnerabilities     [12 vulnerability matches]  
+   ├── by severity: 2 critical, 2 high, 6 medium, 0 low, 0 negligible (2 unknown)
+   └── by status:   2 fixed, 10 not-fixed, 0 ignored 
+NAME          INSTALLED   FIXED-IN    TYPE  VULNERABILITY   SEVERITY 
+busybox       1.35.0-r17  1.35.0-r18  apk   CVE-2023-42366  Medium    
+libcrypto1.1  1.1.1w-r1               apk   CVE-2024-5535   Critical  
+libcrypto1.1  1.1.1w-r1               apk   CVE-2024-4741   High      
+libcrypto1.1  1.1.1w-r1               apk   CVE-2024-9143   Medium    
+libcrypto1.1  1.1.1w-r1               apk   CVE-2024-0727   Medium    
+libcrypto1.1  1.1.1w-r1               apk   CVE-2024-2511   Unknown   
+libssl1.1     1.1.1w-r1               apk   CVE-2024-5535   Critical  
+libssl1.1     1.1.1w-r1               apk   CVE-2024-4741   High      
+libssl1.1     1.1.1w-r1               apk   CVE-2024-9143   Medium    
+libssl1.1     1.1.1w-r1               apk   CVE-2024-0727   Medium    
+libssl1.1     1.1.1w-r1               apk   CVE-2024-2511   Unknown   
+ssl_client    1.35.0-r17  1.35.0-r18  apk   CVE-2023-42366  Medium
+```
+
+### Docker build with Chainguard (Step 5: Build the Chainguard Image)
+
+```
+docker build . -t chainguard-golang-server
+```
+
+
+### Scan results with cgr.dev/chainguard/go:latest image (Step 6: Scan chainguard image with grype)
+
+```
+grype chainguard-golang-server
+ ✔ Loaded image                                                                                chainguard-golang-server:latest
+ ✔ Parsed image                                        sha256:ee420c005a157d69791b9697df42a5bb4f7959a5c1af4993dbee757e54edc0b7
+ ✔ Cataloged contents                                         83349dce8cf1c382b14faa1fff37f41222e263482b0a2e051a4e0cbe839b5893
+   ├── ✔ Packages                        [110 packages]  
+   ├── ✔ File digests                    [9,015 files]  
+   ├── ✔ File metadata                   [9,015 locations]  
+   └── ✔ Executables                     [217 executables]  
+ ✔ Scanned for vulnerabilities     [0 vulnerability matches]  
+   ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
+   └── by status:   0 fixed, 0 not-fixed, 0 ignored 
+No vulnerabilities found
+```
+
+
+### This was an awesome getting started project with chainguard images and how to integrate them in vulnerability management workflows.


### PR DESCRIPTION
The branch contains a markdown file in the vulnz directory name Sir-gits-a-lot.md that has the scan comparison results of chainguard image with that of alpine images.